### PR TITLE
add llb to yaml helpers for inspection/debugging

### DIFF
--- a/context.go
+++ b/context.go
@@ -52,6 +52,9 @@ func (p nullProgress) Channel(opts ...progress.ChannelOption) chan *client.Solve
 
 // WithSession returns a context with the provided session stored.
 func WithSession(ctx context.Context, s Session) context.Context {
+	if sess, ok := s.(*session); ok {
+		ctx = WithImageResolver(ctx, sess.resolver)
+	}
 	return context.WithValue(ctx, sessionKey{}, s)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/containerd/console v1.0.3
+	github.com/coryb/walky v0.0.0-20221229175356-f7b4e8f780fb
 	github.com/docker/docker v23.0.0-rc.1+incompatible
 	github.com/moby/buildkit v0.11.5
 	github.com/opencontainers/go-digest v1.0.0
@@ -18,6 +19,7 @@ require (
 	golang.org/x/sys v0.3.0
 	golang.org/x/term v0.3.0
 	google.golang.org/grpc v1.50.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -63,5 +65,4 @@ require (
 	golang.org/x/time v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20220706185917-7780775163c4 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.9.6 h1:VwnDOgLeoi2du6dAznfmspNqTiwczvjv4K7NxuY9jsY=
@@ -35,6 +36,8 @@ github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lW
 github.com/containerd/ttrpc v1.1.0/go.mod h1:XX4ZTnoOId4HklF4edwc4DcqskFZuvXB1Evzy5KFQpQ=
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
+github.com/coryb/walky v0.0.0-20221229175356-f7b4e8f780fb h1:///d5v+d79c9gSeLVhg6h+M3xr1zPmXbMSLcif8pnBY=
+github.com/coryb/walky v0.0.0-20221229175356-f7b4e8f780fb/go.mod h1:yQClb8EVsuTKXEtOyNhcbDBd6O5ti6gpmb3kllvlqIo=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/leak_test.go
+++ b/leak_test.go
@@ -11,5 +11,10 @@ func TestMain(m *testing.M) {
 		// there is a 3s sleep in (*Client).solve to ensure the sessions are
 		// closed on errors, even if using SharedSession
 		goleak.IgnoreTopFunction("github.com/moby/buildkit/client.(*Client).solve.func2.1.1"),
+
+		// HTTP keepalive
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+		goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
+		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
 	)
 }

--- a/test-data/diff.yaml
+++ b/test-data/diff.yaml
@@ -1,0 +1,19 @@
+- type: DIFF
+  lower: &ref0_0
+    type: SOURCE
+    source: docker-image://docker.io/library/golang:1.20.1
+    platform: linux/amd64
+  upper:
+    type: FILE
+    actions:
+        - type: MKFILE
+          path: /foobar/file
+          mode: "0o644"
+          data: contents
+          input:
+            type: FILE
+            actions:
+                - type: MKDIR
+                  path: /foobar
+                  mode: "0o755"
+                  input: *ref0_0

--- a/test-data/dockerfile.yaml
+++ b/test-data/dockerfile.yaml
@@ -1,0 +1,52 @@
+# [download 2/2] COPY --from=hi hi hi
+- type: FILE
+  actions:
+    - type: COPY
+      src: /hi
+      dest: /hi
+      follow-symlinks: true
+      contents-only: true
+      create-dest-path: true
+      allow-wildcard: true
+      allow-empty-wildcard: true
+      dest-input:
+        # [download 1/2] COPY --from=start start start
+        type: FILE
+        actions:
+            - type: COPY
+              src: /start
+              dest: /start
+              follow-symlinks: true
+              contents-only: true
+              create-dest-path: true
+              allow-wildcard: true
+              allow-empty-wildcard: true
+              dest-input:
+                type: SOURCE
+                source: scratch
+              src-input:
+                # [start 2/2] RUN echo start > start
+                type: EXEC
+                args: [/bin/sh, -c, echo start > start]
+                env: ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+                cwd: /
+                mounts:
+                    - mountpoint: /
+                      type: BIND
+                      output: 0
+                      input: &ref0_0
+                        # [hi 1/2] FROM docker.io/library/busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16
+                        type: SOURCE
+                        source: docker-image://docker.io/library/busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16
+                        platform: linux/arm64
+      src-input:
+        # [hi 2/2] RUN echo hi > hi
+        type: EXEC
+        args: [/bin/sh, -c, echo hi > hi]
+        env: ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+        cwd: /
+        mounts:
+            - mountpoint: /
+              type: BIND
+              output: 0
+              input: *ref0_0

--- a/test-data/image.yaml
+++ b/test-data/image.yaml
@@ -1,0 +1,3 @@
+- type: SOURCE
+  source: docker-image://docker.io/library/golang:1.20.1
+  platform: linux/amd64

--- a/test-data/local.yaml
+++ b/test-data/local.yaml
@@ -1,0 +1,13 @@
+# caching local://.
+- type: FILE
+  actions:
+    - type: COPY
+      src: /
+      dest: /
+      dest-input:
+        type: SOURCE
+        source: scratch
+      src-input:
+        type: SOURCE
+        source: local://.
+        attrs: {local.sharedkeyhint: test-constant, local.unique: test-constant}

--- a/test-data/merge.yaml
+++ b/test-data/merge.yaml
@@ -1,0 +1,20 @@
+- type: MERGE
+  inputs:
+    - type: SOURCE
+      source: docker-image://docker.io/library/golang:1.20.1
+      platform: linux/amd64
+    - type: FILE
+      actions:
+        - type: MKFILE
+          path: /foobar/file
+          mode: "0o644"
+          data: contents
+          input:
+            type: FILE
+            actions:
+                - type: MKDIR
+                  path: /foobar
+                  mode: "0o755"
+                  input:
+                    type: SOURCE
+                    source: scratch

--- a/test-data/mounts.yaml
+++ b/test-data/mounts.yaml
@@ -1,0 +1,29 @@
+- type: EXEC
+  args: [/bin/true]
+  env: [FOO=BAR]
+  cwd: /
+  extra-hosts:
+    - host: home
+      ip: 127.0.0.1
+  security-mode: INSECURE
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input:
+        type: SOURCE
+        source: docker-image://docker.io/library/golang:1.20.1
+        platform: linux/amd64
+    - mountpoint: /git
+      type: BIND
+      readonly: true
+      input:
+        type: SOURCE
+        source: git://github.com/moby/buildkit.git#baaf67ba976460a51ef198abab88baae376c32d8
+        attrs: {git.authheadersecret: GIT_AUTH_HEADER, git.authtokensecret: GIT_AUTH_TOKEN, git.fullurl: 'https://github.com/moby/buildkit.git', git.keepgitdir: "true"}
+    - mountpoint: /scratch
+      type: BIND
+      output: 1
+      input:
+        type: SOURCE
+        source: scratch

--- a/test-data/propagated.yaml
+++ b/test-data/propagated.yaml
@@ -1,0 +1,83 @@
+- type: MOUNT
+  input: &ref2
+    type: EXEC
+    args: [/bin/false]
+    env: [FOO=BAZ]
+    cwd: /
+    mounts:
+        - mountpoint: /
+          type: BIND
+          output: 0
+          input:
+            type: EXEC
+            args: [/bin/true]
+            env: [FOO=BAR]
+            cwd: /
+            mounts:
+                - mountpoint: /
+                  type: BIND
+                  output: 0
+                  input:
+                    type: SOURCE
+                    source: docker-image://docker.io/library/golang:1.20.1
+                    platform: linux/amd64
+                - mountpoint: /cache
+                  type: CACHE
+                  cache-id: myid
+                  sharing: PRIVATE
+                - mountpoint: /git
+                  type: BIND
+                  readonly: true
+                  input: &ref0_0
+                    type: SOURCE
+                    source: git://github.com/moby/buildkit.git#baaf67ba976460a51ef198abab88baae376c32d8
+                    attrs: {git.authheadersecret: GIT_AUTH_HEADER, git.authtokensecret: GIT_AUTH_TOKEN, git.fullurl: 'https://github.com/moby/buildkit.git', git.keepgitdir: "true"}
+                - &ref1_1
+                  mountpoint: /scratch
+                  type: BIND
+                  output: 1
+                  input: &scratch
+                    type: SOURCE
+                    source: scratch
+                - &ref1_2
+                  mountpoint: /src
+                  type: BIND
+                  output: 2
+                  input:
+                    # caching local://.
+                    type: FILE
+                    actions:
+                        - type: COPY
+                          src: /
+                          dest: /
+                          dest-input: *scratch
+                          src-input:
+                            type: SOURCE
+                            source: local://.
+                            attrs: {local.includepattern: '[".golangci.yaml"]', local.sharedkeyhint: test-constant, local.unique: test-constant}
+                - mountpoint: /tmpfs
+                  type: TMPFS
+        - mountpoint: /cache
+          type: CACHE
+          cache-id: myid
+          sharing: PRIVATE
+        - mountpoint: /git
+          type: BIND
+          readonly: true
+          input: *ref0_0
+        - &ref2_1
+          mountpoint: /scratch
+          type: BIND
+          output: 1
+          input: *ref1_1
+        - &ref2_2
+          mountpoint: /src
+          type: BIND
+          output: 2
+          input: *ref1_2
+        - mountpoint: /tmpfs
+          type: TMPFS
+  output: *ref2_1
+- type: MOUNT
+  input: *ref2
+  output: *ref2_2

--- a/test-data/run.yaml
+++ b/test-data/run.yaml
@@ -1,0 +1,11 @@
+- type: EXEC
+  args: [/bin/true]
+  cwd: /
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input:
+        type: SOURCE
+        source: docker-image://docker.io/library/golang:1.20.1
+        platform: linux/amd64

--- a/test-data/runs.yaml
+++ b/test-data/runs.yaml
@@ -1,0 +1,21 @@
+# good build
+- type: EXEC
+  args: [/bin/true]
+  cwd: /
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input: &ref0_0
+        type: SOURCE
+        source: docker-image://docker.io/library/golang:1.20.1
+        platform: linux/amd64
+# bad build
+- type: EXEC
+  args: [/bin/false]
+  cwd: /
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input: *ref0_0

--- a/test-data/scratch.yaml
+++ b/test-data/scratch.yaml
@@ -1,0 +1,2 @@
+- type: SOURCE
+  source: scratch

--- a/yaml.go
+++ b/yaml.go
@@ -1,0 +1,651 @@
+package llblib
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/coryb/walky"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v3"
+)
+
+// ToYAML will serialize the llb.States to a yaml sequence node where each
+// node in the sequence represents the corresponding states passed in.
+func ToYAML(ctx context.Context, states ...llb.State) (*yaml.Node, error) {
+	counter := 0
+	g := graphState{
+		ops:          map[digest.Digest]*pb.Op{},
+		meta:         map[digest.Digest]pb.OpMetadata{},
+		cache:        map[digest.Digest]*yaml.Node{},
+		outputs:      map[string]*yaml.Node{},
+		aliases:      map[digest.Digest]string{},
+		aliasCounter: &counter,
+	}
+
+	nodes := walky.NewSequenceNode()
+	for _, st := range states {
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal state")
+		}
+
+		root, g, err := g.newGraph(def.ToPB())
+		if err != nil {
+			return nil, err
+		}
+		if root == nil {
+			// no error, so we must be solving llb.Scratch()
+			walky.AppendNode(nodes, g.scratchNode())
+			continue
+		}
+
+		node, err := g.visit(root)
+		if err != nil {
+			return nil, err
+		}
+
+		if root.Index > 0 {
+			// We must be returning a mount on an ExecOp. We can't really
+			// express this in the yaml tree structure, so generate a special
+			// MOUNT node to express that we want to extract a mount from an
+			// ExecOp.
+			var output *yaml.Node
+			if mounts := walky.GetKey(node, "mounts"); mounts != nil {
+				for _, m := range mounts.Content {
+					if outputIndex := walky.GetKey(m, "output"); outputIndex != nil {
+						if outputIndex.Value == strconv.Itoa(int(root.Index)) {
+							// found our mount, so set the output
+							anchor := g.anchorName(root.Digest) + "_" + strconv.Itoa(int(root.Index))
+							output = yamlAliasOf(m, anchor)
+							break
+						}
+					}
+				}
+			} else if node.Kind == yaml.AliasNode {
+				// so we want a mount (root index > 0), but it was already
+				// aliased to the right mount.  So the "input" is actually the
+				// parent of the aliased mount, and the "output" is the node we
+				// have. The parent "input" should be in our cache under the
+				// root digest, so lets reset things here and create an alias
+				// to the parent "input".
+				if parent, ok := g.cache[root.Digest]; ok {
+					output = node
+					anchor := g.anchorName(root.Digest)
+					node = yamlAliasOf(parent, anchor)
+				}
+			}
+
+			fromMount := walky.NewMappingNode()
+			yamlAddKV(fromMount, "type", "MOUNT")
+			yamlMapAdd(fromMount, walky.NewStringNode("input"), node)
+			yamlMapAdd(fromMount, walky.NewStringNode("output"), output)
+			// return our synthetic mount result opt
+			node = fromMount
+		}
+
+		walky.AppendNode(nodes, node)
+	}
+	return nodes, nil
+}
+
+type graphState struct {
+	ops          map[digest.Digest]*pb.Op
+	meta         map[digest.Digest]pb.OpMetadata
+	cache        map[digest.Digest]*yaml.Node
+	outputs      map[string]*yaml.Node
+	aliases      map[digest.Digest]string
+	aliasCounter *int
+}
+
+func (g graphState) newGraph(def *pb.Definition) (*pb.Input, graphState, error) {
+	ops := maps.Clone(g.ops)
+	var dgst digest.Digest
+	for _, dt := range def.Def {
+		var pbOp pb.Op
+		if err := (&pbOp).Unmarshal(dt); err != nil {
+			return nil, graphState{}, err
+		}
+		dgst = digest.FromBytes(dt)
+		ops[dgst] = &pbOp
+	}
+	meta := maps.Clone(g.meta)
+	for d, m := range def.Metadata {
+		meta[d] = m
+	}
+
+	if dgst == "" {
+		return nil, graphState{
+			meta:         meta,
+			cache:        g.cache,
+			aliases:      g.aliases,
+			aliasCounter: g.aliasCounter,
+		}, nil
+	}
+	terminal := ops[dgst]
+	return terminal.Inputs[0], graphState{
+		ops:          ops,
+		meta:         meta,
+		cache:        g.cache,
+		aliases:      g.aliases,
+		aliasCounter: g.aliasCounter,
+	}, nil
+}
+
+func (g graphState) anchorName(d digest.Digest) string {
+	if name, ok := g.aliases[d]; ok {
+		return name
+	}
+	name := "ref" + strconv.Itoa(*g.aliasCounter)
+	g.aliases[d] = name
+	*g.aliasCounter++
+	return name
+}
+
+type yamlOpt func(n *yaml.Node) *yaml.Node
+
+func flowStyle(n *yaml.Node) *yaml.Node {
+	n.Style = yaml.FlowStyle
+	return n
+}
+
+func applyOpts(n *yaml.Node, opts ...yamlOpt) *yaml.Node {
+	for _, o := range opts {
+		n = o(n)
+	}
+	return n
+}
+
+func yamlAliasOf(n *yaml.Node, anchor string) *yaml.Node {
+	n.Anchor = anchor
+	alias := &yaml.Node{}
+	alias.Kind = yaml.AliasNode
+	alias.Alias = n
+	alias.Value = n.Anchor
+	return alias
+}
+
+func yamlMapAdd(n, k, v *yaml.Node) {
+	n.Content = append(n.Content, k, v)
+}
+
+func yamlAddInt(n *yaml.Node, name string, i int64) {
+	if i == -1 {
+		return
+	}
+	yamlMapAdd(n,
+		walky.NewStringNode(name),
+		applyOpts(walky.NewIntNode(i)),
+	)
+}
+
+func yamlAddBool(n *yaml.Node, name string, b bool) {
+	if !b {
+		return
+	}
+	yamlMapAdd(n,
+		walky.NewStringNode(name),
+		applyOpts(walky.NewBoolNode(b)),
+	)
+}
+
+func yamlAddKV(n *yaml.Node, k string, v any, opts ...yamlOpt) {
+	if v == "" {
+		return
+	}
+	yamlMapAdd(n,
+		walky.NewStringNode(k),
+		applyOpts(walky.NewStringNode(fmt.Sprint(v)), opts...),
+	)
+}
+
+func yamlAddMap(n *yaml.Node, name string, m map[string]string, opts ...yamlOpt) {
+	if len(m) == 0 {
+		return
+	}
+	attrs := walky.NewMappingNode()
+	keys := maps.Keys(m)
+	sort.Strings(keys)
+	for _, key := range keys {
+		yamlMapAdd(attrs,
+			walky.NewStringNode(key),
+			walky.NewStringNode(m[key]),
+		)
+	}
+	yamlMapAdd(n,
+		walky.NewStringNode(name),
+		applyOpts(attrs, opts...),
+	)
+}
+
+func yamlAddSeq(n *yaml.Node, name string, strs []string, opts ...yamlOpt) {
+	if len(strs) == 0 {
+		return
+	}
+	seq := walky.NewSequenceNode()
+	for _, str := range strs {
+		walky.AppendNode(seq,
+			applyOpts(walky.NewStringNode(str), opts...),
+		)
+	}
+	yamlMapAdd(n,
+		walky.NewStringNode(name),
+		applyOpts(seq, opts...),
+	)
+}
+
+func yamlAddOwner(n *yaml.Node, owner *pb.ChownOpt, opts ...yamlOpt) {
+	if owner != nil {
+		ownerNode := walky.NewDocumentNode()
+		yamlMapAdd(n, walky.NewStringNode("owner"),
+			applyOpts(ownerNode, opts...),
+		)
+		switch u := owner.User.User.(type) {
+		case *pb.UserOpt_ByName:
+			yamlAddKV(ownerNode, "user", u.ByName.Name)
+		case *pb.UserOpt_ByID:
+			yamlAddInt(ownerNode, "user", int64(u.ByID))
+		}
+		switch u := owner.Group.User.(type) {
+		case *pb.UserOpt_ByName:
+			yamlAddKV(ownerNode, "group", u.ByName.Name)
+		case *pb.UserOpt_ByID:
+			yamlAddInt(ownerNode, "group", int64(u.ByID))
+		}
+	}
+}
+
+func yamlAddTime(n *yaml.Node, t int64, opts ...yamlOpt) {
+	if t != -1 {
+		yamlAddKV(n, "timestamp", time.Unix(t, 0).Format(time.RFC3339Nano), opts...)
+	}
+}
+
+func yamlAddMode(n *yaml.Node, mode int32) {
+	if mode != -1 {
+		yamlAddKV(n, "mode", "0o"+strconv.FormatInt(int64(mode), 8))
+	}
+}
+
+func (g graphState) scratchNode() *yaml.Node {
+	if n, ok := g.cache["scratch"]; ok {
+		return yamlAliasOf(n, "scratch")
+	}
+	scratch := walky.NewMappingNode()
+	yamlAddKV(scratch, "type", "SOURCE")
+	yamlAddKV(scratch, "source", "scratch")
+	g.cache["scratch"] = scratch
+	return scratch
+}
+
+func (g graphState) visit(input *pb.Input) (node *yaml.Node, err error) {
+	defer func() {
+		if node != nil && g.cache[input.Digest] == nil {
+			g.cache[input.Digest] = node
+			// add llb.WithCustomName as a comment for the node if found
+			if name, ok := g.meta[input.Digest].Description["llb.customname"]; ok {
+				node.HeadComment = name
+			}
+		}
+	}()
+	if cached, ok := g.cache[input.Digest]; ok {
+		// if alias has mounts (ie ExecOp) then we want to alias the output
+		// mount and not the entire op
+		if mounts := walky.GetKey(cached, "mounts"); mounts != nil {
+			for _, m := range mounts.Content {
+				if output := walky.GetKey(m, "output"); output != nil {
+					if output.Value == strconv.Itoa(int(input.Index)) {
+						cached = m
+						break
+					}
+				}
+			}
+		}
+		anchor := g.anchorName(input.Digest) + "_" + strconv.Itoa(int(input.Index))
+		node := yamlAliasOf(cached, anchor)
+		return node, nil
+	}
+
+	op := g.ops[input.Digest]
+	if op == nil {
+		return nil, errors.Errorf("op %s not found", input.Digest)
+	}
+
+	// any op can have filter constraints, so defer apply them to the
+	// node if there is no error
+	defer func() {
+		if err == nil && node != nil && op.Constraints != nil && len(op.Constraints.Filter) > 0 {
+			constraints := walky.NewMappingNode()
+			yamlMapAdd(node, walky.NewStringNode("constraints"), constraints)
+			yamlAddSeq(constraints, "filters", op.Constraints.Filter)
+		}
+	}()
+
+	switch v := op.Op.(type) {
+	case *pb.Op_Exec:
+		node, err := g.yamlExecOp(op, v.Exec)
+		if err != nil {
+			return nil, err
+		}
+		yamlAddBool(node, "ignore-cache", g.meta[input.Digest].IgnoreCache)
+		return node, nil
+	case *pb.Op_Source:
+		node := g.yamlSourceOp(v.Source)
+		if op.Platform != nil {
+			yamlAddKV(node, "platform",
+				fmt.Sprintf("%s/%s", op.Platform.OS, op.Platform.Architecture),
+			)
+		}
+		return node, err
+	case *pb.Op_File:
+		return g.yamlFileOp(op, v.File)
+	case *pb.Op_Build:
+		return g.yamlBuildOp(op, v.Build)
+	case *pb.Op_Merge:
+		return g.yamlMergeOp(op, v.Merge)
+	case *pb.Op_Diff:
+		return g.yamlDiffOp(op, v.Diff)
+	default:
+		return nil, errors.Errorf("unexpected op type %T", op.Op)
+	}
+}
+
+func (g graphState) yamlExecOp(op *pb.Op, e *pb.ExecOp) (*yaml.Node, error) {
+	node := walky.NewMappingNode()
+	yamlAddKV(node, "type", "EXEC")
+	yamlAddSeq(node, "args", e.Meta.Args, flowStyle)
+	yamlAddSeq(node, "env", e.Meta.Env, flowStyle)
+	yamlAddKV(node, "cwd", e.Meta.Cwd)
+	yamlAddKV(node, "user", e.Meta.User)
+	yamlAddKV(node, "hostname", e.Meta.Hostname)
+	if len(e.Meta.ExtraHosts) > 0 {
+		extraHosts := walky.NewSequenceNode()
+		yamlMapAdd(node,
+			walky.NewStringNode("extra-hosts"),
+			extraHosts)
+		for _, host := range e.Meta.ExtraHosts {
+			n := walky.NewMappingNode()
+			n.Style = yaml.FoldedStyle
+			yamlMapAdd(n,
+				walky.NewStringNode("host"),
+				walky.NewStringNode(host.Host),
+			)
+			yamlMapAdd(n,
+				walky.NewStringNode("ip"),
+				walky.NewStringNode(host.IP),
+			)
+			walky.AppendNode(extraHosts, n)
+		}
+	}
+
+	if e.Network != pb.NetMode_UNSET {
+		yamlAddKV(node, "network-mode", e.Network)
+	}
+	if e.Security != pb.SecurityMode_SANDBOX {
+		yamlAddKV(node, "security-mode", e.Security)
+	}
+
+	if len(e.Secretenv) > 0 {
+		secretEnv := walky.NewMappingNode()
+		yamlMapAdd(node, walky.NewStringNode("secret-envs"), secretEnv)
+		for _, se := range e.Secretenv {
+			walky.AppendNode(secretEnv,
+				walky.NewStringNode(se.Name+"="+se.ID),
+			)
+		}
+	}
+
+	mounts := walky.NewSequenceNode()
+	yamlMapAdd(node, walky.NewStringNode("mounts"), mounts)
+	for _, m := range e.Mounts {
+		mountNode, err := g.yamlMount(op, m)
+		if err != nil {
+			return nil, err
+		}
+		walky.AppendNode(mounts, mountNode)
+	}
+	return node, nil
+}
+
+func (g graphState) yamlMount(op *pb.Op, m *pb.Mount) (*yaml.Node, error) {
+	mount := walky.NewMappingNode()
+	yamlAddKV(mount, "mountpoint", m.Dest)
+	yamlAddKV(mount, "type", m.MountType)
+	yamlAddInt(mount, "output", int64(m.Output))
+	yamlAddBool(mount, "readonly", m.Readonly)
+	yamlAddKV(mount, "source-path", m.Selector)
+	if m.CacheOpt != nil {
+		yamlAddKV(mount, "cache-id", m.CacheOpt.ID)
+		yamlAddKV(mount, "sharing", m.CacheOpt.Sharing)
+	}
+	if m.SecretOpt != nil {
+		yamlAddKV(mount, "secret", m.SecretOpt.ID)
+		yamlAddInt(mount, "uid", int64(m.SecretOpt.Uid))
+		yamlAddInt(mount, "gid", int64(m.SecretOpt.Gid))
+		yamlAddMode(mount, int32(m.SecretOpt.Mode))
+	}
+	if m.SSHOpt != nil {
+		yamlAddKV(mount, "ssh", m.SSHOpt.ID)
+		yamlAddKV(mount, "secret", m.SSHOpt.ID)
+		yamlAddInt(mount, "uid", int64(m.SSHOpt.Uid))
+		yamlAddInt(mount, "gid", int64(m.SSHOpt.Gid))
+		yamlAddMode(mount, int32(m.SSHOpt.Mode))
+	}
+
+	if m.Input < 0 {
+		// scratch mount or tmpfs/cache, don't print empty inputs for
+		// tmpfs/cache, it is implied
+		if m.CacheOpt == nil && m.TmpfsOpt == nil {
+			yamlMapAdd(mount, walky.NewStringNode("input"), g.scratchNode())
+		}
+		return mount, nil
+	}
+	if int(m.Input) >= len(op.Inputs) {
+		return nil, errors.Errorf("invalid op, impossible input %d from op with %d inputs", m.Input, len(op.Inputs))
+	}
+
+	input, err := g.visit(op.Inputs[m.Input])
+	if err != nil {
+		return nil, errors.Wrapf(err, "visiting mount %s", m.Dest)
+	}
+	yamlMapAdd(mount, walky.NewStringNode("input"), input)
+	return mount, nil
+}
+
+func (g graphState) yamlSourceOp(s *pb.SourceOp) *yaml.Node {
+	node := walky.NewMappingNode()
+	yamlAddKV(node, "type", "SOURCE")
+	yamlAddKV(node, "source", s.Identifier)
+	yamlAddMap(node, "attrs", s.Attrs, flowStyle)
+	return node
+}
+
+func (g graphState) yamlFileOp(op *pb.Op, f *pb.FileOp) (*yaml.Node, error) {
+	node := walky.NewMappingNode()
+	yamlAddKV(node, "type", "FILE")
+	actions := walky.NewSequenceNode()
+	yamlMapAdd(node, walky.NewStringNode("actions"), actions)
+	for _, act := range f.Actions {
+		var action *yaml.Node
+		var err error
+		switch a := act.Action.(type) {
+		case *pb.FileAction_Copy:
+			action = g.yamlFileCopy(a.Copy)
+		case *pb.FileAction_Mkdir:
+			action = g.yamlFileMkdir(a.Mkdir)
+		case *pb.FileAction_Mkfile:
+			action = g.yamlFileMkFile(a.Mkfile)
+		case *pb.FileAction_Rm:
+			action = g.yamlFileRm(a.Rm)
+		default:
+			err = errors.Errorf("unexpected file action type %T", a)
+		}
+		if err != nil {
+			return nil, err
+		}
+		inputName := "input"
+		if act.SecondaryInput >= 0 {
+			// for copy we use src-input and dest-input
+			inputName = "dest-input"
+		}
+		if act.Input == -1 {
+			yamlMapAdd(action, walky.NewStringNode(inputName), g.scratchNode())
+		} else {
+			input, err := g.visit(op.Inputs[act.Input])
+			if err != nil {
+				return nil, errors.Wrap(err, "visiting copy input")
+			}
+			yamlMapAdd(action, walky.NewStringNode(inputName), input)
+		}
+		if act.SecondaryInput >= 0 {
+			input, err := g.visit(op.Inputs[act.SecondaryInput])
+			if err != nil {
+				return nil, errors.Wrap(err, "visiting copy source input")
+			}
+			yamlMapAdd(action, walky.NewStringNode("src-input"), input)
+		}
+		walky.AppendNode(actions, action)
+	}
+	return node, nil
+}
+
+func (g graphState) yamlFileCopy(c *pb.FileActionCopy) *yaml.Node {
+	copy := walky.NewMappingNode()
+	yamlAddKV(copy, "type", "COPY")
+	yamlAddKV(copy, "src", c.Src)
+	yamlAddKV(copy, "dest", c.Dest)
+	yamlAddOwner(copy, c.Owner)
+	yamlAddMode(copy, c.Mode)
+	yamlAddBool(copy, "follow-symlinks", c.FollowSymlink)
+	yamlAddBool(copy, "contents-only", c.DirCopyContents)
+	yamlAddBool(copy, "unpack-archive", c.AttemptUnpackDockerCompatibility)
+	yamlAddBool(copy, "create-dest-path", c.CreateDestPath)
+	yamlAddBool(copy, "allow-wildcard", c.AllowWildcard)
+	yamlAddBool(copy, "allow-empty-wildcard", c.AllowEmptyWildcard)
+	yamlAddTime(copy, c.Timestamp)
+	yamlAddSeq(copy, "include-patterns", c.IncludePatterns)
+	yamlAddSeq(copy, "exclude-patterns", c.ExcludePatterns)
+	return copy
+}
+
+func (g graphState) yamlFileMkdir(m *pb.FileActionMkDir) *yaml.Node {
+	mkdir := walky.NewMappingNode()
+	yamlAddKV(mkdir, "type", "MKDIR")
+	yamlAddKV(mkdir, "path", m.Path)
+	yamlAddMode(mkdir, m.Mode)
+	yamlAddBool(mkdir, "create-parents", m.MakeParents)
+	yamlAddOwner(mkdir, m.Owner)
+	yamlAddTime(mkdir, m.Timestamp)
+	return mkdir
+}
+
+func (g graphState) yamlFileMkFile(m *pb.FileActionMkFile) *yaml.Node {
+	mkfile := walky.NewMappingNode()
+	yamlAddKV(mkfile, "type", "MKFILE")
+	yamlAddKV(mkfile, "path", m.Path)
+	yamlAddMode(mkfile, m.Mode)
+	yamlAddKV(mkfile, "data", string(m.Data))
+	yamlAddOwner(mkfile, m.Owner)
+	yamlAddTime(mkfile, m.Timestamp)
+	return mkfile
+}
+
+func (g graphState) yamlFileRm(a *pb.FileActionRm) *yaml.Node {
+	rm := walky.NewMappingNode()
+	yamlAddKV(rm, "type", "RM")
+	yamlAddKV(rm, "path", a.Path)
+	yamlAddKV(rm, "allow-not-found", a.AllowNotFound)
+	yamlAddKV(rm, "allow-wildcard", a.AllowWildcard)
+	return rm
+}
+
+func (g graphState) yamlBuildOp(op *pb.Op, b *pb.BuildOp) (*yaml.Node, error) {
+	node := walky.NewMappingNode()
+	yamlAddKV(node, "type", "BUILD")
+	yamlAddMap(node, "attrs", b.Attrs)
+	if b.Builder == -1 {
+		yamlMapAdd(node, walky.NewStringNode("source"), g.scratchNode())
+	} else {
+		source, err := g.visit(op.Inputs[b.Builder])
+		if err != nil {
+			return nil, errors.Wrap(err, "visiting buildOp source")
+		}
+		yamlMapAdd(node, walky.NewStringNode("source"), source)
+	}
+	inputs := walky.NewMappingNode()
+	yamlMapAdd(node, walky.NewStringNode("inputs"), inputs)
+	inputNames := maps.Keys(b.Inputs)
+	sort.Strings(inputNames)
+	for _, name := range inputNames {
+		if b.Inputs[name].Input == -1 {
+			yamlMapAdd(inputs, walky.NewStringNode(name), g.scratchNode())
+		} else {
+			input, err := g.visit(op.Inputs[b.Inputs[name].Input])
+			if err != nil {
+				return nil, errors.Wrapf(err, "visiting buildOp input %s", name)
+			}
+			yamlMapAdd(inputs, walky.NewStringNode(name), input)
+		}
+	}
+
+	buildInput, buildGraph, err := g.newGraph(b.Def)
+	if err != nil {
+		return nil, errors.Wrap(err, "building graph for buildOp")
+	}
+	build, err := buildGraph.visit(buildInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "visiting build for buildOp")
+	}
+	yamlMapAdd(node, walky.NewStringNode("build"), build)
+	return node, nil
+}
+
+func (g graphState) yamlMergeOp(op *pb.Op, m *pb.MergeOp) (*yaml.Node, error) {
+	node := walky.NewMappingNode()
+	yamlAddKV(node, "type", "MERGE")
+	if len(m.Inputs) > 0 {
+		inputs := walky.NewSequenceNode()
+		yamlMapAdd(node, walky.NewStringNode("inputs"), inputs)
+		for _, inputIx := range m.Inputs {
+			if inputIx.Input == -1 {
+				walky.AppendNode(inputs, g.scratchNode())
+			} else {
+				input, err := g.visit(op.Inputs[inputIx.Input])
+				if err != nil {
+					return nil, errors.Wrapf(err, "visiting merge input %d", inputIx.Input)
+				}
+				walky.AppendNode(inputs, input)
+			}
+		}
+	}
+	return node, nil
+}
+
+func (g graphState) yamlDiffOp(op *pb.Op, d *pb.DiffOp) (*yaml.Node, error) {
+	node := walky.NewMappingNode()
+	yamlAddKV(node, "type", "DIFF")
+	if d.Lower.Input < 0 || int(d.Lower.Input) >= len(op.Inputs) {
+		return nil, errors.Errorf("invalid diff op, lower index %d of with %d inputs", d.Lower.Input, len(op.Inputs))
+	}
+	lower, err := g.visit(op.Inputs[d.Lower.Input])
+	if err != nil {
+		return nil, err
+	}
+	yamlMapAdd(node, walky.NewStringNode("lower"), lower)
+
+	if d.Upper.Input < 0 || int(d.Upper.Input) >= len(op.Inputs) {
+		return nil, errors.Errorf("invalid diff op, upper index %d of with %d inputs", d.Upper.Input, len(op.Inputs))
+	}
+	upper, err := g.visit(op.Inputs[d.Upper.Input])
+	if err != nil {
+		return nil, err
+	}
+	yamlMapAdd(node, walky.NewStringNode("upper"), upper)
+	return node, nil
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,0 +1,202 @@
+package llblib_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coryb/llblib"
+	"github.com/coryb/walky"
+	"github.com/moby/buildkit/client/llb"
+	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestYAML(t *testing.T) {
+	t.Parallel()
+	slv := llblib.NewSolver()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	cln, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	require.NoError(t, err, "creating buildkit client")
+
+	t.Cleanup(func() {
+		if err := cln.Close(); err != nil {
+			t.Errorf("Failed to close client: %s", err)
+		}
+	})
+
+	states := func(s ...llb.State) []llb.State {
+		return s
+	}
+
+	for _, tt := range []struct {
+		states   []llb.State
+		expected string
+	}{{
+		states:   states(llb.Scratch()),
+		expected: "scratch",
+	}, {
+		states:   states(slv.Local(".")),
+		expected: "local",
+	}, {
+		states:   states(llb.Image("golang:1.20.1", llb.LinuxAmd64)),
+		expected: "image",
+	}, {
+		states: states(
+			llb.Diff(
+				llb.Image("golang:1.20.1", llb.LinuxAmd64),
+				llb.Image("golang:1.20.1", llb.LinuxAmd64).File(
+					llb.Mkdir("/foobar", 0o755),
+				).File(
+					llb.Mkfile("/foobar/file", 0o644, []byte("contents")),
+				),
+			),
+		),
+		expected: "diff",
+	}, {
+		states: states(
+			llb.Merge([]llb.State{
+				llb.Image("golang:1.20.1", llb.LinuxAmd64),
+				llb.Scratch().File(
+					llb.Mkdir("/foobar", 0o755),
+				).File(
+					llb.Mkfile("/foobar/file", 0o644, []byte("contents")),
+				),
+			}),
+		),
+		expected: "merge",
+	}, {
+		states: states(
+			llb.Image("golang:1.20.1", llb.LinuxAmd64).Run(
+				llb.Args([]string{"/bin/true"}),
+			).Root(),
+		),
+		expected: "run",
+	}, {
+		states: states(
+			llb.Image("golang:1.20.1", llb.LinuxAmd64).Run(
+				llb.Args([]string{"/bin/true"}),
+				llb.WithCustomName("good build"),
+			).Root(),
+			llb.Image("golang:1.20.1", llb.LinuxAmd64).Run(
+				llb.Args([]string{"/bin/false"}),
+				llb.WithCustomName("bad build"),
+			).Root(),
+		),
+		expected: "runs",
+	}, {
+		states: states(
+			llb.Image("golang:1.20.1", llb.LinuxAmd64).Run(
+				llb.Args([]string{"/bin/true"}),
+				llb.Security(llb.SecurityModeInsecure),
+				llb.AddEnv("FOO", "BAR"),
+				llb.AddExtraHost("home", net.IPv4(127, 0, 0, 1)),
+				llb.AddMount("/scratch", llb.Scratch()),
+				llb.AddMount("/git",
+					llb.Git("https://github.com/moby/buildkit.git", "baaf67ba976460a51ef198abab88baae376c32d8",
+						llb.KeepGitDir(),
+					),
+					llb.Readonly,
+				),
+			).Root(),
+		),
+		expected: "mounts",
+	}, {
+		states: func() []llb.State {
+			mp := llblib.Persistent(
+				llb.Image("golang:1.20.1", llb.LinuxAmd64),
+				llb.AddMount("/scratch", llb.Scratch()),
+				llb.AddMount("/git",
+					llb.Git("https://github.com/moby/buildkit.git", "baaf67ba976460a51ef198abab88baae376c32d8",
+						llb.KeepGitDir(),
+					),
+					llb.Readonly,
+				),
+				llb.AddMount("/src", slv.Local(".",
+					llb.IncludePatterns([]string{".golangci.yaml"}),
+				)),
+			)
+			mp.Run(
+				llb.Args([]string{"/bin/true"}),
+				llb.AddEnv("FOO", "BAR"),
+				llb.AddMount("/cache", llb.Scratch(),
+					llb.AsPersistentCacheDir("myid", llb.CacheMountPrivate),
+				),
+				llb.AddMount("/tmpfs", llb.Scratch(), llb.Tmpfs()),
+			)
+			mp.Run(
+				llb.Args([]string{"/bin/false"}),
+				llb.AddEnv("FOO", "BAZ"),
+				llb.AddMount("/cache", llb.Scratch(),
+					llb.AsPersistentCacheDir("myid", llb.CacheMountPrivate),
+				),
+				llb.AddMount("/tmpfs", llb.Scratch(), llb.Tmpfs()),
+			)
+			scratch, _ := mp.GetMount("/scratch")
+			src, _ := mp.GetMount("/src")
+			return states(scratch, src)
+		}(),
+		expected: "propagated",
+	}, {
+		states: states(llblib.Dockerfile(
+			[]byte(`
+				FROM busybox AS start
+				RUN echo start > start
+				FROM busybox AS hi
+				RUN echo hi > hi
+				FROM scratch AS download
+				COPY --from=start start start
+				COPY --from=hi hi hi
+				FROM busybox
+				RUN false # <- should not run
+			`),
+			llb.Scratch(),
+			llblib.WithTarget("download"),
+			llblib.WithTargetPlatform(&specsv1.Platform{
+				OS: "linux", Architecture: "arm64",
+			}),
+		)),
+		expected: "dockerfile",
+	}} {
+		tt := tt
+		t.Run(tt.expected, func(t *testing.T) {
+			t.Parallel()
+			sess, err := slv.NewSession(ctx, cln, llblib.LoadProgress(ctx))
+			require.NoError(t, err, "creating session")
+
+			t.Cleanup(func() {
+				if err := sess.Release(); err != nil {
+					t.Error("Failed to release session")
+				}
+			})
+			ctx = llblib.WithSession(ctx, sess)
+
+			node, err := llblib.ToYAML(ctx, tt.states...)
+			require.NoError(t, err, "converting state to YAML")
+
+			walky.Walk(node, walky.StringWalker("local.sharedkeyhint", func(n *yaml.Node) error {
+				n.Value = "test-constant"
+				return nil
+			}))
+
+			walky.Walk(node, walky.StringWalker("local.unique", func(n *yaml.Node) error {
+				n.Value = "test-constant"
+				return nil
+			}))
+
+			got, err := yaml.Marshal(node)
+			require.NoError(t, err, "marshalling YAML")
+
+			file := filepath.Join("test-data", tt.expected+".yaml")
+			expected, err := os.ReadFile(file)
+			require.NoError(t, err, "reading file: %s", file)
+			require.Equal(t, string(expected), string(got))
+		})
+	}
+}


### PR DESCRIPTION
This adds a bit of code, but is mostly straightforward data translations from the `pb.Op` data into `*yaml.Node`.  Added a bunch of yaml helpers to simplify adding data, the "zero" value is skipped (where "zero" value in this context is how buildkit/proto defaults things, so things like "-1" for integers generally means it is unset).

We walk the digraph, where we start at the last def in the llb.Defs, which is the target def from the llb.  Then walk down all the inputs recursively and generate the yaml.  We keep ahold of all the yaml objects so we can short-circuit the calculations and for "seen" nodes just use yaml aliasing for displaying. 