### PR TITLE
fix some yaml marshalling issues

### DIFF
--- a/test-data/forward.yaml
+++ b/test-data/forward.yaml
@@ -1,0 +1,16 @@
+- type: EXEC
+  args: [cat, /tmp/unix.sock]
+  env: [SSH_AUTH_SOCK=/tmp/unix.sock]
+  cwd: /
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input:
+        type: SOURCE
+        source: docker-image://docker.io/library/busybox:latest
+        platform: linux/amd64
+    - mountpoint: /tmp/unix.sock
+      type: SSH
+      ssh: sha256:1be2e4bbd95ae9923ecbc938c27258dd34270988a892f721811283b541016b2b
+      mode: "0o600"

--- a/test-data/mounts.yaml
+++ b/test-data/mounts.yaml
@@ -3,8 +3,7 @@
   env: [FOO=BAR]
   cwd: /
   extra-hosts:
-    - host: home
-      ip: 127.0.0.1
+    - {host: home, ip: 127.0.0.1}
   security-mode: INSECURE
   mounts:
     - mountpoint: /

--- a/test-data/script.yaml
+++ b/test-data/script.yaml
@@ -1,0 +1,17 @@
+- type: EXEC
+  args:
+    - /bin/sh
+    - -c
+    - |-
+      echo multi
+      echo line
+      echo statement
+  cwd: /
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input:
+        type: SOURCE
+        source: docker-image://docker.io/library/busybox:latest
+        platform: linux/amd64

--- a/test-data/secrets.yaml
+++ b/test-data/secrets.yaml
@@ -1,0 +1,15 @@
+- type: EXEC
+  args: [cat, /secret]
+  cwd: /
+  mounts:
+    - mountpoint: /
+      type: BIND
+      output: 0
+      input:
+        type: SOURCE
+        source: docker-image://docker.io/library/busybox:latest
+        platform: linux/amd64
+    - mountpoint: /secret
+      type: SECRET
+      secret: test-constant
+      mode: "0o400"


### PR DESCRIPTION
* secret/ssh uid/gid defaults to 0, dont write those
* only bind mounts can have an output or input
    * cache, secret, ssh (forward), and tmpfs cannot
* for run args, only use succinct flowStyle if the args dont contain newlines, otherwise args with embedded scripts are hard to read.