### PR TITLE
add FromReader wrapper for progress

### DIFF
--- a/progress/fromreader.go
+++ b/progress/fromreader.go
@@ -1,0 +1,44 @@
+package progress
+
+import (
+	"io"
+	"time"
+
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/identity"
+	"github.com/opencontainers/go-digest"
+)
+
+// FromReader is a lightly modified copy version from the buildx progress here:
+// https://github.com/docker/buildx/blob/v0.10.4/util/progress/fromreader.go#L12
+
+// FromReader will report the progress of reading from the ReadCloser.
+func FromReader(p Progress, name string, rc io.ReadCloser) {
+	dgst := digest.FromBytes([]byte(identity.NewID()))
+	tm := time.Now()
+
+	vtx := client.Vertex{
+		Digest:  dgst,
+		Name:    name,
+		Started: &tm,
+	}
+
+	ch := p.Channel()
+	defer close(ch)
+
+	ch <- &client.SolveStatus{
+		Vertexes: []*client.Vertex{&vtx},
+	}
+
+	_, err := io.Copy(io.Discard, rc)
+
+	tm2 := time.Now()
+	vtx2 := vtx
+	vtx2.Completed = &tm2
+	if err != nil {
+		vtx2.Error = err.Error()
+	}
+	ch <- &client.SolveStatus{
+		Vertexes: []*client.Vertex{&vtx2},
+	}
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -134,14 +134,14 @@ func TestYAML(t *testing.T) {
 	}, {
 		states: states(llblib.Dockerfile(
 			[]byte(`
-				FROM busybox AS start
+				FROM busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16 AS start
 				RUN echo start > start
-				FROM busybox AS hi
+				FROM busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16 AS hi
 				RUN echo hi > hi
 				FROM scratch AS download
 				COPY --from=start start start
 				COPY --from=hi hi hi
-				FROM busybox
+				FROM busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16
 				RUN false # <- should not run
 			`),
 			llb.Scratch(),


### PR DESCRIPTION
Basically adding a modified version of the [buildx progress wrapper](https://github.com/docker/buildx/blob/v0.10.4/util/progress/fromreader.go#L12) that can be used to monitor the progress of a generic ReadCloser.  This is useful for a docker-load export (which is not yet supported directly via llblib)