### PR TITLE
fix yaml serialization for multiple file actions

### DIFF
--- a/test-data/diff.yaml
+++ b/test-data/diff.yaml
@@ -6,14 +6,13 @@
   upper:
     type: FILE
     actions:
+        - &ref1_1
+          type: MKDIR
+          path: /foobar
+          mode: "0o755"
+          input: *ref0_0
         - type: MKFILE
           path: /foobar/file
           mode: "0o644"
           data: contents
-          input:
-            type: FILE
-            actions:
-                - type: MKDIR
-                  path: /foobar
-                  mode: "0o755"
-                  input: *ref0_0
+          input: *ref1_1

--- a/test-data/file.yaml
+++ b/test-data/file.yaml
@@ -1,0 +1,39 @@
+- type: FILE
+  actions:
+    - &ref0_1
+      type: MKDIR
+      path: /foo
+      mode: "0o755"
+      input: &scratch
+        type: SOURCE
+        source: scratch
+    - &ref0_2
+      type: MKFILE
+      path: /foo/bar
+      mode: "0o644"
+      data: bar content
+      input: *ref0_1
+    - &ref0_3
+      type: MKFILE
+      path: /foo/bad
+      mode: "0o644"
+      data: bad content
+      input: *ref0_2
+    - &ref0_4
+      type: COPY
+      src: /
+      dest: /foo
+      dest-input: *ref0_3
+      src-input:
+        type: FILE
+        actions:
+            - type: MKFILE
+              path: /baz
+              mode: "0o644"
+              data: baz content
+              input: *scratch
+    - type: RM
+      path: /foo/bad
+      allow-not-found: "false"
+      allow-wildcard: "false"
+      input: *ref0_4

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -40,9 +40,7 @@ func TestYAML(t *testing.T) {
 			llb.Diff(
 				llb.Image("golang:1.20.1", llb.LinuxAmd64),
 				llb.Image("golang:1.20.1", llb.LinuxAmd64).File(
-					llb.Mkdir("/foobar", 0o755),
-				).File(
-					llb.Mkfile("/foobar/file", 0o644, []byte("contents")),
+					llb.Mkdir("/foobar", 0o755).Mkfile("/foobar/file", 0o644, []byte("contents")),
 				),
 			),
 		),
@@ -174,6 +172,23 @@ func TestYAML(t *testing.T) {
 			).Root(),
 		),
 		expected: "forward",
+	}, {
+		states: states(
+			llb.Scratch().File(
+				llb.Mkdir(
+					"foo", 0o755,
+				).Mkfile(
+					"foo/bar", 0o644, []byte("bar content"),
+				).Mkfile(
+					"foo/bad", 0o644, []byte("bad content"),
+				).Copy(
+					llb.Scratch().File(llb.Mkfile("baz", 0o644, []byte("baz content"))), "/", "foo",
+				).Rm(
+					"foo/bad",
+				),
+			),
+		),
+		expected: "file",
 	}} {
 		tt := tt
 		t.Run(tt.expected, func(t *testing.T) {


### PR DESCRIPTION
When we have multiple file actions within one operation we need to account for each action potentially being used as the input for any subsequent actions.