### PR TITLE
add CopyDirContentsOnly llb.CopyOption

### DIFF
--- a/fileaction.go
+++ b/fileaction.go
@@ -1,0 +1,9 @@
+package llblib
+
+import "github.com/moby/buildkit/client/llb"
+
+// CopyDirContentsOnly is an llb.CopyOption to indicate that the contents of the
+// src directory should be copied, rather than the directory itself.
+var CopyDirContentsOnly = copyOptionFunc(func(ci *llb.CopyInfo) {
+	ci.CopyDirContentsOnly = true
+})


### PR DESCRIPTION
helper function missing from llb, adding it here for now.