### PR TITLE
refactor image resolver to allow for sharable cache

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package llblib
 
 import (
 	"context"
+	"os"
 
 	"github.com/coryb/llblib/progress"
 	"github.com/moby/buildkit/client"
@@ -12,6 +13,7 @@ type (
 	progressKey      struct{}
 	sessionKey       struct{}
 	imageResolverKey struct{}
+	envKey           string
 )
 
 // WithProgress returns a context with the provided Progress stored.
@@ -81,4 +83,25 @@ func LoadImageResolver(ctx context.Context) llb.ImageMetaResolver {
 		return nil
 	}
 	return r
+}
+
+// WithEnv is used to set env vars on a context.
+func WithEnv(ctx context.Context, key, value string) context.Context {
+	return context.WithValue(ctx, envKey(key), value)
+}
+
+// LookupEnv will fetch a env var stored on the context or default to calling
+// os.LookupEnv
+func LookupEnv(ctx context.Context, key string) (value string, ok bool) {
+	if val, ok := ctx.Value(envKey(key)).(string); ok {
+		return val, ok
+	}
+	return os.LookupEnv(key)
+}
+
+// Getenv will fetch an env var stored on the context or default to calling
+// os.Getenv
+func Getenv(ctx context.Context, key string) (value string) {
+	val, _ := LookupEnv(ctx, key)
+	return val
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,34 @@
+package llblib
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithEnv(t *testing.T) {
+	ctx := context.Background()
+
+	// verify missing env condition
+	require.Equal(t, "", Getenv(ctx, "FOO"))
+	got, ok := LookupEnv(ctx, "FOO")
+	require.False(t, ok)
+	require.Equal(t, "", got)
+
+	// verify fallback to os env
+	os.Setenv("FOO", "BAR")
+	require.Equal(t, "BAR", Getenv(ctx, "FOO"))
+	got, ok = LookupEnv(ctx, "FOO")
+	require.True(t, ok)
+	require.Equal(t, "BAR", got)
+
+	// verify context env, and os env unmodified
+	ctx = WithEnv(ctx, "FOO", "BAZ")
+	require.Equal(t, os.Getenv("FOO"), "BAR")
+	require.Equal(t, "BAZ", Getenv(ctx, "FOO"))
+	got, ok = LookupEnv(ctx, "FOO")
+	require.True(t, ok)
+	require.Equal(t, "BAZ", got)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/coryb/walky v0.0.0-20221229175356-f7b4e8f780fb
 	github.com/docker/cli v23.0.0-rc.1+incompatible
-	github.com/docker/docker v23.0.0-rc.1+incompatible
+	github.com/docker/docker v24.0.5+incompatible
 	github.com/moby/buildkit v0.11.5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4Kfc
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v23.0.0-rc.1+incompatible h1:Dmn88McWuHc7BSNN1s6RtfhMmt6ZPQAYUEf7FhqpiQI=
-github.com/docker/docker v23.0.0-rc.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.5+incompatible h1:WmgcE4fxyI6EEXxBRxsHnZXrO1pQ3smi0k/jho4HLeY=
+github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestYAML(t *testing.T) {
 	t.Parallel()
-	r := newTestRunner(t, withTimeout(10*time.Second))
+	r := newTestRunner(t, withTimeout(60*time.Second))
 
 	states := func(s ...llb.State) []llb.State {
 		return s


### PR DESCRIPTION
We want to share the resolve image cache between many operations for the same Solver.  This also adds an interface to get an llb.ImageMetaResolver from the Solver so we can resolve images outside of the Solve/Session operations.

We move the inflight-cache request deduping into a new llbcache package and the image resolver is simplified quite a bit.