### PR TITLE
add registry push option

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/solver/pb"
-	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DockerfileOpts alias dockerfile2llb.ConvertOpt
@@ -53,7 +53,7 @@ func WithBuildArg(k, v string) DockerfileOption {
 }
 
 // WithTargetPlatform will set the platform for the Dockerfile build.
-func WithTargetPlatform(p *specsv1.Platform) DockerfileOption {
+func WithTargetPlatform(p *ocispec.Platform) DockerfileOption {
 	return dockerfileOptionFunc(func(o *dockerfileOpts) {
 		o.TargetPlatform = p
 	})
@@ -100,11 +100,11 @@ func Dockerfile(dockerfile []byte, buildContext llb.State, opts ...DockerfileOpt
 }
 
 func directSolve(ctx context.Context, dockerfile []byte, opts DockerfileOpts) (llb.State, error) {
-	state, _, _, _, err := dockerfile2llb.Dockerfile2LLB(ctx, dockerfile, opts)
+	state, img, _, _, err := dockerfile2llb.Dockerfile2LLB(ctx, dockerfile, opts)
 	if err != nil {
 		return llb.Scratch(), errtrace.Wrap(err)
 	}
-	return *state, nil
+	return withImageConfig(*state, img), nil
 }
 
 const (

--- a/docker_test.go
+++ b/docker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/coryb/llblib"
 	"github.com/moby/buildkit/client/llb"
-	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +16,7 @@ func TestDockerfile(t *testing.T) {
 	t.Parallel()
 	r := newTestRunner(t)
 
-	linux := specsv1.Platform{
+	linux := ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
 	}
@@ -42,7 +42,7 @@ func TestDockerfile(t *testing.T) {
 	tdir := t.TempDir()
 	req := r.Solver.Build(st, llblib.Download(tdir))
 
-	err := r.Run(t, req)
+	_, err := r.Run(t, req)
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(filepath.Join(tdir, "start"))
@@ -58,7 +58,7 @@ func TestDockerfileSyntax(t *testing.T) {
 	t.Parallel()
 	r := newTestRunner(t)
 
-	linux := specsv1.Platform{
+	linux := ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
 	}
@@ -87,7 +87,7 @@ RUN false # <- should not run
 	tdir := t.TempDir()
 	req := r.Solver.Build(st, llblib.Download(tdir))
 
-	err := r.Run(t, req)
+	_, err := r.Run(t, req)
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(filepath.Join(tdir, "start"))
@@ -107,7 +107,7 @@ func TestDockerfileBuildContexts(t *testing.T) {
 	t.Parallel()
 	r := newTestRunner(t)
 
-	linux := specsv1.Platform{
+	linux := ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
 	}
@@ -147,7 +147,7 @@ func TestDockerfileBuildContexts(t *testing.T) {
 	)
 
 	req := r.Solver.Build(st)
-	err = r.Run(t, req)
+	_, err = r.Run(t, req)
 	require.NoError(t, err)
 }
 
@@ -155,7 +155,7 @@ func TestDockerfileRunMounts(t *testing.T) {
 	t.Parallel()
 	r := newTestRunner(t)
 
-	linux := specsv1.Platform{
+	linux := ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
 	}
@@ -186,6 +186,6 @@ func TestDockerfileRunMounts(t *testing.T) {
 	r.Solver.AddSecretFile(filepath.Join(secretDir, "secret"), "", llb.SecretID("my.secret"))
 
 	req := r.Solver.Build(st)
-	err = r.Run(t, req)
+	_, err = r.Run(t, req)
 	require.NoError(t, err)
 }

--- a/examples/build/main.go
+++ b/examples/build/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/coryb/llblib"
 	"github.com/coryb/llblib/progress"
 	"github.com/moby/buildkit/client/llb"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -40,12 +40,12 @@ func main() {
 		"/root/.cache/go-build",
 		"/go/pkg/mod",
 	}
-	platform := ocispecs.Platform{OS: "linux", Architecture: runtime.GOARCH}
+	platform := ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 
 	// ----
 
 	ctx := context.Background()
-	cln, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	cln, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
 		log.Fatalf("Failed to create client: %s", err)
 	}
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	for _, cmd := range setup {
-		root = root.Run(
+		root = llblib.Run(root,
 			llb.Shlex(cmd),
 			llblib.AddEnvs(env),
 			llblib.AddCacheMounts(cachePaths, cacheID, llb.CacheMountPrivate),
@@ -107,7 +107,7 @@ func main() {
 	prog := progress.NewProgress()
 	defer prog.Close()
 
-	sess, err := slv.NewSession(ctx, cln, prog)
+	sess, err := slv.NewSession(ctx, cln, prog, isMoby)
 	if err != nil {
 		log.Panicf("failed to create session: %+v", err)
 	}

--- a/examples/container/main.go
+++ b/examples/container/main.go
@@ -12,29 +12,29 @@ import (
 	"github.com/coryb/llblib"
 	"github.com/coryb/llblib/progress"
 	"github.com/moby/buildkit/client/llb"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func main() {
 	localCwd, _ := os.Getwd()
-	platform := ocispecs.Platform{OS: "linux", Architecture: runtime.GOARCH}
+	platform := ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 
 	// ----
 
 	ctx := context.Background()
-	cli, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	cli, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
 		log.Fatalf("Failed to create client: %s", err)
 	}
 
 	slv := llblib.NewSolver(llblib.WithCwd(localCwd))
-	root := llb.Image("alpine:latest@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501", llb.Platform(platform)).Dir("/")
+	root := llblib.Image("alpine:latest@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501", llb.Platform(platform)).Dir("/")
 	mounts := llblib.RunOptions{
 		llb.AddMount("/scratch", llb.Scratch()),
 		llb.AddMount("/local", slv.Local(".", llb.IncludePatterns([]string{"*"}), llb.ExcludePatterns([]string{"*"}))),
 		llb.AddMount("/git", llb.Git("https://github.com/moby/buildkit.git", "baaf67ba976460a51ef198abab88baae376c32d8", llb.KeepGitDir())),
 		llb.AddMount("/http", llb.HTTP("https://raw.githubusercontent.com/moby/buildkit/master/README.md", llb.Filename("README.md"), llb.Chmod(0o600))),
-		llb.AddMount("/image", llb.Image("busybox:latest@sha256:acaddd9ed544f7baf3373064064a51250b14cfe3ec604d65765a53da5958e5f5", llb.Platform(platform))),
+		llb.AddMount("/image", llblib.Image("busybox:latest@sha256:acaddd9ed544f7baf3373064064a51250b14cfe3ec604d65765a53da5958e5f5", llb.Platform(platform))),
 		slv.AddSecretFile("go.mod", "/secret/go.mod"),
 	}
 
@@ -46,7 +46,7 @@ func main() {
 	prog := progress.NewProgress(progress.WithOutput(console.Current()))
 	defer prog.Close()
 
-	sess, err := slv.NewSession(ctx, cli, prog)
+	sess, err := slv.NewSession(ctx, cli, prog, isMoby)
 	if err != nil {
 		log.Panicf("failed to create session: %+v", err)
 	}

--- a/examples/docker-fail/main.go
+++ b/examples/docker-fail/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	cli, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
 		log.Fatalf("Failed to create client: %s", err)
 	}
@@ -43,7 +43,7 @@ func main() {
 	prog := progress.NewProgress(progress.WithOutput(console.Current()))
 	defer prog.Close()
 
-	sess, err := slv.NewSession(ctx, cli, prog)
+	sess, err := slv.NewSession(ctx, cli, prog, isMoby)
 	if err != nil {
 		log.Panicf("failed to create session: %+v", err)
 	}

--- a/examples/docker/main.go
+++ b/examples/docker/main.go
@@ -12,19 +12,19 @@ import (
 	"github.com/coryb/llblib"
 	"github.com/coryb/llblib/progress"
 	"github.com/moby/buildkit/client/llb"
-	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func main() {
 	ctx := context.Background()
-	cli, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	cli, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
 		log.Fatalf("Failed to create client: %s", err)
 	}
 
 	slv := llblib.NewSolver()
 
-	p := specsv1.Platform{OS: "linux", Architecture: runtime.GOARCH}
+	p := ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 
 	dockerfile := `
 		FROM alpine
@@ -44,7 +44,7 @@ func main() {
 	prog := progress.NewProgress()
 	defer prog.Close()
 
-	sess, err := slv.NewSession(ctx, cli, prog)
+	sess, err := slv.NewSession(ctx, cli, prog, isMoby)
 	if err != nil {
 		log.Panicf("failed to create session: %+v", err)
 	}

--- a/examples/fail/main.go
+++ b/examples/fail/main.go
@@ -18,14 +18,14 @@ var differScript []byte
 
 func main() {
 	ctx := context.Background()
-	cli, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	cli, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
 		log.Fatalf("Failed to create client: %s", err)
 	}
 
 	slv := llblib.NewSolver()
 
-	root := llb.Image("golang:1.20", llb.LinuxArm64).Dir("/").File(llb.Mkdir("/scratch", 0o777))
+	root := llblib.Image("golang:1.20", llb.LinuxArm64).Dir("/").File(llb.Mkdir("/scratch", 0o777))
 
 	mounts := llblib.RunOptions{
 		llb.AddMount("/scratch", llb.Scratch()),
@@ -65,7 +65,7 @@ func main() {
 	prog := progress.NewProgress()
 	defer prog.Close()
 
-	sess, err := slv.NewSession(ctx, cli, prog)
+	sess, err := slv.NewSession(ctx, cli, prog, isMoby)
 	if err != nil {
 		log.Panicf("failed to create session: %+v", err)
 	}

--- a/examples/frontend/main.go
+++ b/examples/frontend/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
+	cli, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
 		log.Fatalf("Failed to create client: %s", err)
 	}
@@ -41,7 +41,7 @@ func main() {
 	prog := progress.NewProgress()
 	defer prog.Close()
 
-	sess, err := slv.NewSession(ctx, cli, prog)
+	sess, err := slv.NewSession(ctx, cli, prog, isMoby)
 	if err != nil {
 		log.Panicf("failed to create session: %+v", err)
 	}

--- a/exit_test.go
+++ b/exit_test.go
@@ -25,7 +25,7 @@ func TestExitError(t *testing.T) {
 		).Root(),
 	)
 
-	err := r.Run(t, req)
+	_, err := r.Run(t, req)
 	var exitError *gwpb.ExitError
 	require.ErrorAs(t, err, &exitError)
 	require.Equal(t, uint32(99), exitError.ExitCode)

--- a/frontend.go
+++ b/frontend.go
@@ -8,7 +8,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
-	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	mdispec "github.com/moby/docker-image-spec/specs-go/v1"
 )
 
 // FrontendOption can be used to modify a Frontend request.
@@ -151,10 +151,11 @@ func Frontend(source string, opts ...FrontendOption) llb.State {
 						}
 						// we need to parse the document again bc WithImageConfig
 						// does not apply the USER config.
-						var img specsv1.Image
+						var img mdispec.DockerOCIImage
 						if err := json.Unmarshal(config, &img); err != nil {
 							return nil, errtrace.Errorf("failed to parse config from frontend request: %w", err)
 						}
+						result = withImageConfig(result, &img)
 						if img.Config.User != "" {
 							result = result.User(img.Config.User)
 						}

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,19 @@ module github.com/coryb/llblib
 go 1.21
 
 require (
+	braces.dev/errtrace v0.3.0
+	github.com/brunoga/deep v1.2.3
 	github.com/containerd/console v1.0.4
 	github.com/coryb/walky v0.0.0-20221229175356-f7b4e8f780fb
+	github.com/distribution/reference v0.5.0
 	github.com/docker/cli v25.0.3+incompatible
 	github.com/docker/docker v25.0.3+incompatible // master (v25.0.0-dev)
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/moby/buildkit v0.13.2
+	github.com/moby/docker-image-spec v1.3.1
 	github.com/muesli/cancelreader v0.2.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.8.4
 	github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c
 	go.uber.org/goleak v1.2.1
@@ -24,10 +28,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	braces.dev/errtrace v0.3.0
-	github.com/distribution/reference v0.5.0
-)
+require github.com/docker/go-connections v0.5.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
@@ -42,7 +43,6 @@ require (
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
-	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
@@ -59,11 +59,11 @@ require (
 	github.com/in-toto/in-toto-golang v0.5.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
+github.com/brunoga/deep v1.2.3 h1:3k2qXf9i8pD1J7e+hcuRMi37aP31AKUHbH8Oe8lSQwk=
+github.com/brunoga/deep v1.2.3/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -124,6 +126,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/in-toto/in-toto-golang v0.5.0 h1:hb8bgwr0M2hGdDsLjkJ3ZqJ8JFLL/tgYdAxF/XEFBbY=
 github.com/in-toto/in-toto-golang v0.5.0/go.mod h1:/Rq0IZHLV7Ku5gielPT4wPHJfH1GdHMCq8+WPxw8/BE=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=

--- a/image.go
+++ b/image.go
@@ -2,25 +2,177 @@ package llblib
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 
+	"braces.dev/errtrace"
+	"github.com/brunoga/deep"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/imagemetaresolver"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	mdispec "github.com/moby/docker-image-spec/specs-go/v1"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+type imageConfigKey struct{}
+
+type imageConfigState struct {
+	config  *mdispec.DockerOCIImage
+	mutator func(context.Context, *mdispec.DockerOCIImage) error
+}
+
+// imageConfig will attempt to build the image config from values stored on the
+// llb.State.
+func imageConfig(ctx context.Context, st llb.State) (*mdispec.DockerOCIImage, error) {
+	cs, err := loadImageConfigState(ctx, st)
+	if err != nil {
+		return nil, errtrace.Wrap(err)
+	}
+	if cs.mutator != nil {
+		if err := cs.mutator(ctx, cs.config); err != nil {
+			return nil, errtrace.Errorf("failed to apply image config mutator: %w", err)
+		}
+	}
+	return cs.config, nil
+}
+
+// loadImageConfigState will return the most recent imageConfigState stored
+// on the llb.State.
+func loadImageConfigState(ctx context.Context, st llb.State) (imageConfigState, error) {
+	v, err := st.Value(ctx, imageConfigKey{})
+	if err != nil {
+		return imageConfigState{}, errtrace.Wrap(err)
+	}
+	if v == nil {
+		return imageConfigState{}, nil
+	}
+	cs, ok := v.(imageConfigState)
+	if !ok {
+		return imageConfigState{}, errtrace.Errorf("unexpected type %T for image config", v)
+	}
+	return cs, nil
+}
+
+// withImageConfig will store the image config on the llb.State.
+func withImageConfig(st llb.State, config *mdispec.DockerOCIImage) llb.State {
+	return st.WithValue(imageConfigKey{}, imageConfigState{config: config})
+}
+
+// withImageConfigMutator will store the image config mutator on the llb.State.
+// The mutator will be applied to the image config when imageConfig is called.
+func withImageConfigMutator(st llb.State, m func(context.Context, *mdispec.DockerOCIImage) error) llb.State {
+	return st.Async(func(ctx context.Context, st llb.State, c *llb.Constraints) (llb.State, error) {
+		cs, err := loadImageConfigState(ctx, st)
+		if err != nil {
+			return llb.State{}, errtrace.Wrap(err)
+		}
+		if cs.config == nil {
+			var plat ocispec.Platform
+			if c.Platform != nil {
+				plat = *c.Platform
+			}
+			cs.config = &mdispec.DockerOCIImage{
+				Image: ocispec.Image{
+					Platform: plat,
+				},
+			}
+		} else {
+			// deep copy so modifying does not mutate pointers lower in the
+			// state stack.
+			cp, err := deep.Copy(cs.config)
+			if err != nil {
+				return llb.State{}, errtrace.Errorf("failed to copy image config: %w", err)
+			}
+			cs.config = cp
+		}
+		if cs.mutator == nil {
+			cs.mutator = m
+			return st.WithValue(imageConfigKey{}, cs), nil
+		}
+		// chain previous mutator to the one passed in
+		prev := cs.mutator
+		cs.mutator = func(ctx context.Context, c *mdispec.DockerOCIImage) error {
+			if err := prev(ctx, c); err != nil {
+				return errtrace.Wrap(err)
+			}
+			return errtrace.Wrap(m(ctx, c))
+		}
+		return st.WithValue(imageConfigKey{}, cs), nil
+	})
+}
 
 // ResolvedImage returns an llb.State where the image will be resolved with the
 // image configuration applied to the state.  The resolved image digest will
 // also be applied to the state to ensure this state is always consistent
-// during the solve execution.  Note that `WithImageResolver` should be used
-// on the context provided to the buildkit solve requests, otherwise an
-// un-resolved llb.Image will be used.
+// during the solve execution.
 func ResolvedImage(ref string, opts ...llb.ImageOption) llb.State {
+	return Image(ref, append(opts, llb.ResolveDigest(true))...)
+}
+
+// Image is similar to llb.Image but the image config will be preserved
+// so that the llb.State can be pushed to a registry.
+func Image(ref string, opts ...llb.ImageOption) llb.State {
 	return llb.Scratch().Async(func(ctx context.Context, _ llb.State, c *llb.Constraints) (llb.State, error) {
-		if resolver := LoadImageResolver(ctx); resolver != nil {
-			opts = append(opts,
-				llb.WithMetaResolver(resolver),
-				llb.ResolveDigest(true),
-			)
-			return llb.Image(ref, opts...), nil
+		capturingMetaResolver := &capturingMetaResolver{
+			resolver: LoadImageResolver(ctx),
 		}
-		return llb.Image(ref, opts...), nil
+
+		img := llb.Image(ref,
+			append(opts, llb.WithMetaResolver(capturingMetaResolver))...,
+		)
+		// this will un-async the image allowing us to capture the image config
+		img.Output().Vertex(ctx, c)
+		return img.Async(func(ctx context.Context, st llb.State, c *llb.Constraints) (llb.State, error) {
+			if len(capturingMetaResolver.config) == 0 {
+				return st, nil
+			}
+			var config mdispec.DockerOCIImage
+			if err := json.Unmarshal(capturingMetaResolver.config, &config); err != nil {
+				return llb.State{}, errtrace.Errorf("failed to unmarshal image config: %w", err)
+			}
+			return withImageConfig(st, &config), nil
+		}), nil
 	})
+}
+
+// imageResolverOption is a helper to extract the ImageMetaResolver if provided
+// on the llb.ImageOptions.
+func imageResolverOption(ctx context.Context, opts ...llb.ImageOption) sourceresolver.ImageMetaResolver {
+	ii := llb.ImageInfo{}
+	for _, opt := range opts {
+		opt.SetImageOption(&ii)
+	}
+	// HACK: the metaResolver field is private, so we have to use reflection to
+	// access it.  TODO maybe we can make this exported or add an accessor
+	// to llb.ImageInfo?
+	f := reflect.ValueOf(&ii).Elem().FieldByName("metaResolver")
+	if !f.IsValid() {
+		return LoadImageResolver(ctx)
+	}
+	if f.IsNil() || f.IsZero() {
+		return LoadImageResolver(ctx)
+	}
+	// We won't be modifying the resolver, just using it.  Also the lifespan
+	// of the resolver is longer than the places we call this function,
+	// so this should be safe.
+	f = reflect.NewAt(f.Type(), f.Addr().UnsafePointer()).Elem()
+	return f.Interface().(sourceresolver.ImageMetaResolver)
+}
+
+type capturingMetaResolver struct {
+	config   []byte
+	resolver sourceresolver.ImageMetaResolver
+}
+
+func (s *capturingMetaResolver) ResolveImageConfig(ctx context.Context, ref string, opt sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	if s.resolver == nil {
+		s.resolver = imagemetaresolver.Default()
+	}
+	ref, dgst, config, err := s.resolver.ResolveImageConfig(ctx, ref, opt)
+	if err != nil {
+		return "", "", nil, err
+	}
+	s.config = config
+	return ref, dgst, config, nil
 }

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,80 @@
+package llblib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/imagemetaresolver"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+// mockResolver1 is a mock sourceresolver.ImageMetaResolver that is implemented
+// with a value receiver to test some edge cases with the reflection logic in
+// imageResolverOption.
+type mockResolver1 struct{}
+
+func (mockResolver1) ResolveImageConfig(ctx context.Context, ref string, opt sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	return "", "", nil, nil
+}
+
+// mockResolver2 is a mock sourceresolver.ImageMetaResolver that is implemented
+// with a pointer receiver to test some edge cases with the reflection logic in
+// imageResolverOption.  We can also verify that our resolver is called by
+// looking at the resolved value.
+type mockResolver2 struct {
+	resolved string
+}
+
+func (r *mockResolver2) ResolveImageConfig(ctx context.Context, ref string, opt sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	r.resolved = ref
+	return "", "", nil, nil
+}
+
+func TestImageResolverOption(t *testing.T) {
+	ctx := context.Background()
+
+	// verify imageResolverOption with value receiver resolver
+	var resolverA sourceresolver.ImageMetaResolver = mockResolver1{}
+	got := imageResolverOption(ctx, llb.WithMetaResolver(resolverA))
+	_, _, _, err := got.ResolveImageConfig(ctx, "test", sourceresolver.Opt{})
+	require.NoError(t, err)
+	require.Equal(t, resolverA, got)
+
+	// verify imageResolverOption with pointer to value receiver resolver
+	resolverB := &mockResolver1{}
+	got = imageResolverOption(ctx, llb.WithMetaResolver(resolverB))
+	_, _, _, err = got.ResolveImageConfig(ctx, "test", sourceresolver.Opt{})
+	require.NoError(t, err)
+	require.Equal(t, resolverB, got)
+
+	// verify imageResolverOption with pointer receiver resolver
+	resolverC := &mockResolver2{}
+	got = imageResolverOption(ctx, llb.WithMetaResolver(resolverC))
+	require.Equal(t, resolverC, got)
+	_, _, _, err = got.ResolveImageConfig(ctx, "test", sourceresolver.Opt{})
+	require.NoError(t, err)
+	require.Equal(t, "test", resolverC.resolved)
+
+	// verify imageResolverOption with "real" default resolver, we will actually
+	// resolve the image here.
+	resolverD := imagemetaresolver.Default()
+	got = imageResolverOption(ctx, llb.WithMetaResolver(resolverD))
+	require.Equal(t, resolverD, got)
+	_, _, _, err = got.ResolveImageConfig(ctx, "docker.io/library/busybox:latest", sourceresolver.Opt{})
+	require.NoError(t, err)
+
+	// verify imageResolverOption with our capturing resolver, wrapping the
+	// "real" default resolver, we will also verify the config is captured
+	// after resolving.
+	resolverE := &capturingMetaResolver{
+		resolver: imagemetaresolver.Default(),
+	}
+	got = imageResolverOption(ctx, llb.WithMetaResolver(resolverE))
+	require.Equal(t, resolverE, got)
+	_, _, cfg, err := got.ResolveImageConfig(ctx, "docker.io/library/busybox:latest", sourceresolver.Opt{})
+	require.NoError(t, err)
+	require.Equal(t, resolverE.config, cfg)
+}

--- a/lint_test.go
+++ b/lint_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/coryb/llblib"
 	"github.com/moby/buildkit/client/llb"
-	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +22,7 @@ func TestLint(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	currentPlatform := specsv1.Platform{
+	currentPlatform := ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
 	}
@@ -39,7 +39,7 @@ func TestLint(t *testing.T) {
 		"golangci/golangci-lint:"+GolangCILintVersion,
 		llb.Platform(currentPlatform),
 	).Run(
-		llb.Args([]string{"golangci-lint", "run", "--timeout", "3m", "--fast"}),
+		llb.Args([]string{"golangci-lint", "run", "--timeout", "9m"}),
 		// ensure go mod cache location is in our persistent cache dir
 		llb.AddEnv("GOMODCACHE", "/root/.cache/go-mod"),
 		llb.Dir(cwd),
@@ -54,6 +54,6 @@ func TestLint(t *testing.T) {
 		),
 	).Root()
 
-	err = r.Run(t, r.Solver.Build(st))
+	_, err = r.Run(t, r.Solver.Build(st))
 	require.NoError(t, err)
 }

--- a/mounts.go
+++ b/mounts.go
@@ -74,7 +74,7 @@ func (pm *persistentMounts) Run(opts ...llb.RunOption) {
 
 	runOpts = append(runOpts, opts...)
 
-	execState := pm.root.Run(runOpts...)
+	execState := Run(pm.root, runOpts...)
 	pm.root = execState.Root()
 	for _, mountpoint := range mountpoints {
 		pm.states[mountpoint] = execState.GetMount(mountpoint)

--- a/push.go
+++ b/push.go
@@ -1,0 +1,67 @@
+package llblib
+
+import (
+	"strconv"
+
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/client"
+)
+
+type registryPushOpts struct {
+	attrs map[string]string
+}
+
+// RegistryPushOption can be used to modify a registry push request.
+type RegistryPushOption interface {
+	SetRegistryPushOption(*registryPushOpts)
+}
+
+type registryPushOptionFunc func(*registryPushOpts)
+
+func (f registryPushOptionFunc) SetRegistryPushOption(o *registryPushOpts) {
+	f(o)
+}
+
+// WithInsecurePush will allow pushing to an insecure registry.
+func WithInsecurePush() RegistryPushOption {
+	return registryPushOptionFunc(func(o *registryPushOpts) {
+		o.attrs["registry.insecure"] = "true"
+	})
+}
+
+// WithPushByDigest will push the image by digest.
+func WithPushByDigest() RegistryPushOption {
+	return registryPushOptionFunc(func(o *registryPushOpts) {
+		o.attrs["push-by-digest"] = "true"
+	})
+}
+
+// WithCompression will set the compression type for the push.
+func WithCompression(compression string, force bool) RegistryPushOption {
+	return registryPushOptionFunc(func(o *registryPushOpts) {
+		o.attrs["compression"] = compression
+		o.attrs["force-compression"] = strconv.FormatBool(force)
+		if compression == "zstd" || compression == "estargz" {
+			o.attrs["oci-mediatypes"] = "true"
+		}
+	})
+}
+
+// RegistryPush will push the request build state to the registry.
+func RegistryPush(ref reference.Named, opts ...RegistryPushOption) RequestOption {
+	o := &registryPushOpts{
+		attrs: map[string]string{
+			"name": ref.String(),
+			"push": "true",
+		},
+	}
+	for _, opt := range opts {
+		opt.SetRegistryPushOption(o)
+	}
+	return requestOptionFunc(func(r *Request) {
+		r.exports = append(r.exports, client.ExportEntry{
+			Type:  client.ExporterImage,
+			Attrs: o.attrs,
+		})
+	})
+}

--- a/push_test.go
+++ b/push_test.go
@@ -1,0 +1,142 @@
+package llblib_test
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coryb/llblib"
+	"github.com/distribution/reference"
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func startRegistry(ctx context.Context, t *testing.T) int {
+	t.Helper()
+	dockerClient, err := client.NewClientWithOpts(
+		client.WithAPIVersionNegotiation(),
+	)
+	require.NoError(t, err)
+	defer dockerClient.Close()
+
+	cfg := container.Config{
+		Image: "registry:2.8.3",
+	}
+
+	hostCfg := &container.HostConfig{
+		PublishAllPorts: true,
+		AutoRemove:      true,
+	}
+
+	body, err := dockerClient.ImagePull(ctx, cfg.Image, dockertypes.ImagePullOptions{})
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, body)
+	require.NoError(t, err)
+	body.Close()
+
+	service, err := dockerClient.ContainerCreate(ctx, &cfg, hostCfg, nil, nil, "")
+	require.NoError(t, err)
+
+	err = dockerClient.ContainerStart(ctx, service.ID, container.StartOptions{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := dockerClient.ContainerStop(context.Background(), service.ID, container.StopOptions{})
+		require.NoError(t, err)
+	})
+
+	inspect, err := dockerClient.ContainerInspect(ctx, service.ID)
+	require.NoError(t, err)
+
+	for _, port := range inspect.NetworkSettings.Ports[nat.Port("5000/tcp")] {
+		// ignore v6
+		if !strings.Contains(port.HostIP, ":") {
+			port, err := strconv.Atoi(port.HostPort)
+			require.NoError(t, err)
+			return port
+		}
+	}
+	t.Fatalf("failed to find container port 5000/tcp")
+	return 0
+}
+
+func registryRef(t *testing.T, registryPort int, name string) reference.Named {
+	t.Helper()
+	ref, err := reference.ParseNormalizedNamed("127.0.0.1:" + strconv.Itoa(registryPort) + "/" + name)
+	require.NoError(t, err)
+	return ref
+}
+
+func TestRegistryPushImage(t *testing.T) {
+	r := newTestRunner(t, withTimeout(60*time.Second))
+
+	currentPlatform := specsv1.Platform{
+		OS:           "linux",
+		Architecture: runtime.GOARCH,
+	}
+
+	regPort1 := startRegistry(r.Context, t)
+	regPort2 := startRegistry(r.Context, t)
+
+	req := r.Solver.Build(
+		llblib.Image("alpine:latest", llb.Platform(currentPlatform)),
+		llblib.RegistryPush(registryRef(t, regPort1, "llblib-test/registry-push-image")),
+		llblib.RegistryPush(registryRef(t, regPort2, "llblib-test/registry-push-image")),
+	)
+
+	resp, err := r.Run(t, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.ExporterResponse)
+	require.Contains(t, resp.ExporterResponse[exptypes.ExporterImageDigestKey], "sha256:")
+}
+
+func TestRegistryPushDockerfile(t *testing.T) {
+	r := newTestRunner(t, withTimeout(60*time.Second))
+
+	currentPlatform := specsv1.Platform{
+		OS:           "linux",
+		Architecture: runtime.GOARCH,
+	}
+
+	regPort1 := startRegistry(r.Context, t)
+	regPort2 := startRegistry(r.Context, t)
+
+	dockerfile := `
+		FROM busybox AS start
+		RUN echo start > start
+		FROM busybox AS hi
+		RUN echo hi > hi
+		FROM scratch AS download
+		COPY --from=start start start
+		COPY --from=hi hi hi
+		FROM busybox
+		RUN false # <- should not run
+	`
+	st := llblib.Dockerfile(
+		[]byte(dockerfile),
+		llb.Scratch(),
+		llblib.WithTarget("download"),
+		llblib.WithTargetPlatform(&currentPlatform),
+	)
+
+	req := r.Solver.Build(
+		st,
+		llblib.RegistryPush(registryRef(t, regPort1, "llblib-test/registry-push-dockerfile")),
+		llblib.RegistryPush(registryRef(t, regPort2, "llblib-test/registry-push-dockerfile")),
+	)
+
+	resp, err := r.Run(t, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.ExporterResponse)
+	require.Contains(t, resp.ExporterResponse[exptypes.ExporterImageDigestKey], "sha256:")
+}

--- a/session.go
+++ b/session.go
@@ -2,16 +2,24 @@ package llblib
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"braces.dev/errtrace"
 	"github.com/coryb/llblib/progress"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	bksess "github.com/moby/buildkit/session"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	// ExporterImageConfigKey is the key used to store the image config in the
+	// client.SolveResponse.ExporterResponse returned from Session.Do.
+	ExporterImageConfigKey = "llblib.containerimage.config"
 )
 
 // Session provides a long running session used to solve requests.
@@ -31,6 +39,7 @@ type session struct {
 	attachables []bksess.Attachable
 	releasers   []func() error
 	client      *client.Client
+	isMoby      bool
 	resolver    *resolver
 	progress    progress.Progress
 }
@@ -92,12 +101,25 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 		return res, nil
 	}
 
-	solveOpt.Exports = req.exports
 	def, err := req.state.Marshal(ctx)
 	if err != nil {
 		return nil, errtrace.Errorf("failed to marshal state: %w", err)
 	}
 
+	solveOpt.Exports = slices.Clone(req.exports)
+	if s.isMoby {
+		for i, export := range solveOpt.Exports {
+			if export.Type == client.ExporterImage {
+				// I don't know why this is necessary, but if we are using
+				// buildkit inside of docker service, then we need to use the
+				// "moby" type exporter instead of the "image" exporter used
+				// with "normal" buildkit clients.
+				solveOpt.Exports[i].Type = "moby"
+			}
+		}
+	}
+
+	var imageconfig []byte
 	res, err := s.client.Build(ctx, solveOpt, "llblib", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		gwReq := gateway.SolveRequest{
 			Evaluate:   req.evaluate,
@@ -111,10 +133,31 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 			}
 			return nil, errors.Join(err, errtrace.Wrap(moreErr))
 		}
+		if spec, err := imageConfig(ctx, req.state); err != nil {
+			return nil, errtrace.Wrap(err)
+		} else if spec != nil {
+			imageconfig, err = json.Marshal(spec)
+			if err != nil {
+				return nil, errtrace.Wrap(err)
+			}
+		}
+		if res != nil && res.Metadata != nil {
+			if _, ok := res.Metadata[exptypes.ExporterImageConfigKey]; !ok {
+				// overwrite the image config with our preserve image config
+				// so we collect additional metatdata
+				res.AddMeta(exptypes.ExporterImageConfigKey, imageconfig)
+			}
+		}
 		return res, errtrace.Wrap(err)
 	}, s.progress.Channel(progress.AddLabel(req.Label)))
 	if err != nil {
 		return nil, errtrace.Errorf("solve failed: %w", err)
+	}
+	if len(imageconfig) > 0 {
+		if res.ExporterResponse == nil {
+			res.ExporterResponse = map[string]string{}
+		}
+		res.ExporterResponse[ExporterImageConfigKey] = string(imageconfig)
 	}
 	return res, nil
 }

--- a/solver.go
+++ b/solver.go
@@ -51,10 +51,10 @@ type Solver interface {
 	// buildkit service.
 	Container(root llb.State, opts ...ContainerOption) Request
 
-	// NewSession will return a session to used to send the solve requests to
+	// NewSession will return a session used to send the solve requests to
 	// buildkit.  Note that `Release` MUST be called on the returned `Session`
 	// to free resources.
-	NewSession(ctx context.Context, cln *client.Client, p progress.Progress) (Session, error)
+	NewSession(ctx context.Context, cln *client.Client, p progress.Progress, isMoby bool) (Session, error)
 
 	// ImageResolver returns an llb.ImageMetaResolver to resolve images.  The
 	// resolver will use a common cache for all image lookups done via this
@@ -384,7 +384,7 @@ func (cw *aliveConnWaiter) Read(b []byte) (n int, err error) {
 	return errtrace.Wrap2(cw.Conn.Read(b))
 }
 
-func (s *solver) NewSession(ctx context.Context, cln *client.Client, p progress.Progress) (Session, error) {
+func (s *solver) NewSession(ctx context.Context, cln *client.Client, p progress.Progress, isMoby bool) (Session, error) {
 	if s.err != nil {
 		return nil, errtrace.Errorf("solver in error state, cannot proceed: %w", s.err)
 	}
@@ -476,6 +476,7 @@ func (s *solver) NewSession(ctx context.Context, cln *client.Client, p progress.
 		attachables: attachables,
 		releasers:   releasers,
 		client:      cln,
+		isMoby:      isMoby,
 		localDirs:   localDirs,
 		resolver:    resolver,
 		progress:    p,

--- a/state.go
+++ b/state.go
@@ -2,10 +2,17 @@ package llblib
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
 	"braces.dev/errtrace"
+	"github.com/kballard/go-shellquote"
 	"github.com/moby/buildkit/client/llb"
+	mdispec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Digest returns the digest for the state.
@@ -14,4 +21,383 @@ func Digest(st llb.State) (digest.Digest, error) {
 	c := &llb.Constraints{}
 	dgst, _, _, _, err := st.Output().Vertex(ctx, c).Marshal(ctx, c)
 	return dgst, errtrace.Wrap(err)
+}
+
+type layerHistory struct {
+	empty bool
+	desc  string
+}
+
+func commitHistory(img *mdispec.DockerOCIImage, commit layerHistory) {
+	img.History = append(img.History, ocispec.History{
+		// Set a zero value on Created for more reproducible builds
+		Created:    &time.Time{},
+		CreatedBy:  commit.desc,
+		Comment:    "llblib.v0",
+		EmptyLayer: commit.empty,
+	})
+	// Set a zero value on Created for more reproducible builds
+	img.Created = &time.Time{}
+}
+
+// Merge is similar to llb.Merge but also commits history to the image config.
+func Merge(states []llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	switch len(states) {
+	case 0:
+		return llb.Scratch()
+	case 1:
+		return states[0]
+	}
+	return llb.Merge(states, opts...).Async(func(ctx context.Context, st llb.State, c *llb.Constraints) (llb.State, error) {
+		// if any of the merged states has an image config, then preserve
+		// the first one we see.
+		for _, ms := range states {
+			cs, err := loadImageConfigState(ctx, ms)
+			if err != nil {
+				continue
+			}
+			if cs.config == nil {
+				continue
+			}
+			st = st.WithValue(imageConfigKey{}, cs)
+			break
+		}
+
+		msgs := []string{}
+		for _, ms := range states {
+			dgst, _, _, _, err := ms.Output().Vertex(ctx, c).Marshal(ctx, c)
+			if err != nil {
+				return llb.State{}, errtrace.Wrap(err)
+			}
+			msgs = append(msgs, dgst.Encoded()+":/")
+		}
+
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			commitHistory(img, layerHistory{
+				empty: false,
+				desc:  "MERGE " + strings.Join(msgs, " "),
+			})
+			return nil
+		}), nil
+	})
+}
+
+// Diff is similar to llb.Diff but also commits history to the image config.
+func Diff(lower, upper llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	return llb.Diff(lower, upper, opts...).Async(func(ctx context.Context, st llb.State, c *llb.Constraints) (llb.State, error) {
+		lowerDgst, _, _, _, err := lower.Output().Vertex(ctx, c).Marshal(ctx, c)
+		if err != nil {
+			return llb.State{}, errtrace.Wrap(err)
+		}
+		upperDgst, _, _, _, err := upper.Output().Vertex(ctx, c).Marshal(ctx, c)
+		if err != nil {
+			return llb.State{}, errtrace.Wrap(err)
+		}
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Author = ""
+			img.RootFS = ocispec.RootFS{}
+			img.Config = mdispec.DockerOCIImageConfig{
+				ImageConfig: ocispec.ImageConfig{
+					Labels: img.Config.Labels,
+				},
+			}
+
+			commitHistory(img, layerHistory{
+				empty: false,
+				desc:  "DIFF " + lowerDgst.Encoded() + ":/ " + upperDgst.Encoded() + ":/",
+			})
+			return nil
+		}), nil
+	})
+}
+
+// Run is similar to llb.Run but also commits history to the image config.
+func Run(st llb.State, opts ...llb.RunOption) llb.ExecState {
+	ei := &llb.ExecInfo{State: st}
+	for _, opt := range opts {
+		opt.SetRunOption(ei)
+	}
+	es := st.Run(opts...)
+	es.State = es.State.Async(func(ctx context.Context, st llb.State, c *llb.Constraints) (llb.State, error) {
+		args, err := ei.State.GetArgs(ctx)
+		if err != nil {
+			return llb.State{}, fmt.Errorf("failed to get args from state for history: %w", err)
+		}
+		return withImageConfigMutator(st, func(ctx context.Context, img *mdispec.DockerOCIImage) error {
+			commitHistory(img, layerHistory{
+				empty: false,
+				desc:  "RUN " + shellquote.Join(args...),
+			})
+			return nil
+		}), nil
+	})
+	return es
+}
+
+// ApplyRun is similar to llb.Run but also commits history to the image config.
+// It will always resolve the ExecState.Root from llb.Run, and can be used like:
+//
+//	st = st.With(
+//		llblib.ApplyRun(llb.Shlex("touch /file1")),
+//		llblib.ApplyRun(llb.Shlex("touch /file2")),
+//	)
+func ApplyRun(opts ...llb.RunOption) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return Run(st, opts...).Root()
+	}
+}
+
+// Copy will copy files from one state to another, and also commits history to
+// the image config.
+func Copy(src llb.State, srcPath, destPath string, opts ...llb.CopyOption) llb.StateOption {
+	return func(dest llb.State) llb.State {
+		st := dest.File(
+			llb.Copy(src, srcPath, destPath, opts...),
+		)
+		return st.Async(func(ctx context.Context, st llb.State, c *llb.Constraints) (llb.State, error) {
+			dgst, _, _, _, err := src.Output().Vertex(ctx, c).Marshal(ctx, c)
+			if err != nil {
+				return llb.State{}, errtrace.Wrap(err)
+			}
+			return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+				commitHistory(img, layerHistory{
+					empty: false,
+					desc:  shellquote.Join("COPY", dgst.Encoded()+":"+srcPath, destPath),
+				})
+				return nil
+			}), nil
+		})
+	}
+}
+
+// DefaultDir sets the WORKDIR working directory for the image, also records the
+// WorkingDir to the image config.
+func DefaultDir(d string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		st = st.Dir(d)
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.WorkingDir = d
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  shellquote.Join("WORKDIR", d),
+			})
+			return nil
+		})
+	}
+}
+
+// DefaultUser sets the USER for the image, also records the User to the image
+// config.
+func DefaultUser(u string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		st = st.User(u)
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.User = u
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  shellquote.Join("USER", u),
+			})
+			return nil
+		})
+	}
+}
+
+// AddDefaultEnv sets an ENV environment variable for the image, also records
+// the environment variable to the image config.
+func AddDefaultEnv(key, value string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		st = st.AddEnv(key, value)
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.Env = append(img.Config.Env, key+"="+value)
+			// In Dockerfile, multiple ENV can be specified in the same ENV command
+			// leading to one history element. This checks if the previous history
+			// committed was also an ENV, in which case it should just add to the
+			// previous history element.
+			numHistory := len(img.History)
+			if numHistory > 0 && strings.HasPrefix(img.History[numHistory-1].CreatedBy, "ENV") {
+				img.History[numHistory-1].CreatedBy += " " + shellquote.Join(key) + "=" + shellquote.Join(value)
+			} else {
+				commitHistory(img, layerHistory{
+					empty: true,
+					desc:  "ENV " + shellquote.Join(key) + "=" + shellquote.Join(value),
+				})
+			}
+			return nil
+		})
+	}
+}
+
+// Entrypoint records the ENTRYPOINT to image config.
+func Entrypoint(entrypoint ...string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.Entrypoint = entrypoint
+			out, err := json.Marshal(entrypoint)
+			if err != nil {
+				return fmt.Errorf("failed to marshal ENTRYPOINT as json: %w", err)
+			}
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "ENTRYPOINT " + string(out),
+			})
+			return nil
+		})
+	}
+}
+
+// Cmd records the CMD command arguments to the image config.
+func Cmd(cmd ...string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.Cmd = cmd
+			out, err := json.Marshal(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to marshal CMD as json: %w", err)
+			}
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "CMD " + string(out),
+			})
+			return nil
+		})
+	}
+}
+
+// AddLabel records a LABEL to the image config.
+func AddLabel(key, value string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			if img.Config.Labels == nil {
+				img.Config.Labels = make(map[string]string)
+			}
+
+			if curVal, ok := img.Config.Labels[key]; ok && curVal == value {
+				// No need to add the label if it already exists with the same value
+				return nil
+			}
+
+			img.Config.Labels[key] = value
+
+			// In Dockerfile, multiple labels can be specified in the same LABEL command
+			// leading to one history element. This checks if the previous history
+			// committed was also a label, in which case it should just add to the
+			// previous history element.
+			numHistory := len(img.History)
+			if numHistory > 0 && strings.HasPrefix(img.History[numHistory-1].CreatedBy, "LABEL") {
+				img.History[numHistory-1].CreatedBy += " " + shellquote.Join(key) + "=" + shellquote.Join(value)
+			} else {
+				commitHistory(img, layerHistory{
+					empty: true,
+					desc:  "LABEL " + shellquote.Join(key) + "=" + shellquote.Join(value),
+				})
+			}
+			return nil
+		})
+	}
+}
+
+// AddExposedPort records an EXPOSE port to the image config.
+func AddExposedPort(port string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			if img.Config.ExposedPorts == nil {
+				img.Config.ExposedPorts = make(map[string]struct{})
+			}
+			if _, ok := img.Config.ExposedPorts[port]; ok {
+				// No need to add the port if it already exists
+				return nil
+			}
+			img.Config.ExposedPorts[port] = struct{}{}
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "EXPOSE " + port,
+			})
+			return nil
+		})
+	}
+}
+
+// AddVolume records a VOLUME to the image config.
+func AddVolume(mountpoint string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			if img.Config.Volumes == nil {
+				img.Config.Volumes = make(map[string]struct{})
+			}
+			if _, ok := img.Config.Volumes[mountpoint]; ok {
+				// No need to add the volume if it already exists
+				return nil
+			}
+			img.Config.Volumes[mountpoint] = struct{}{}
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "VOLUME " + mountpoint,
+			})
+			return nil
+		})
+	}
+}
+
+// StopSignal records the STOPSIGNAL to the image config.
+func StopSignal(signal string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.StopSignal = signal
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "STOPSIGNAL " + signal,
+			})
+			return nil
+		})
+	}
+}
+
+// DockerHealthcheck records the HEALTHCHECK configuration to the image config.
+func DockerHealthcheck(hc mdispec.HealthcheckConfig) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.Healthcheck = &hc
+			out, err := json.Marshal(hc)
+			if err != nil {
+				return fmt.Errorf("failed to marshal HEALTHCHECK as json: %w", err)
+			}
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "HEALTHCHECK " + string(out),
+			})
+			return nil
+		})
+	}
+}
+
+// AddDockerOnBuild records the ONBUILD instruction to the image config.
+func AddDockerOnBuild(instruction string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.OnBuild = append(img.Config.OnBuild, instruction)
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "ONBUILD " + instruction,
+			})
+			return nil
+		})
+	}
+}
+
+// DockerRunShell sets the SHELL for the image config.
+func DockerRunShell(shell ...string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			img.Config.Shell = shell
+			out, err := json.Marshal(shell)
+			if err != nil {
+				return fmt.Errorf("failed to marshal SHELL as json: %w", err)
+			}
+			commitHistory(img, layerHistory{
+				empty: true,
+				desc:  "SHELL " + string(out),
+			})
+			return nil
+		})
+	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,193 @@
+package llblib_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coryb/llblib"
+	"github.com/moby/buildkit/client/llb"
+	v1 "github.com/moby/docker-image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func alpine(r testRunner) llb.State {
+	return llblib.Image(
+		"alpine@sha256:216266c86fc4dcef5619930bd394245824c2af52fd21ba7c6fa0e618657d4c3b",
+		llb.LinuxAmd64,
+		llb.WithMetaResolver(r.Solver.ImageResolver(r.Client, r.Progress)),
+	)
+}
+
+func expectConfig(t *testing.T, cfgData string) {
+	t.Helper()
+	// serialize the cfg to yaml for easier test comparison
+	config := map[string]any{}
+	err := json.Unmarshal([]byte(cfgData), &config)
+	require.NoError(t, err)
+	got, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	shortName := filepath.Base(t.Name())
+	file := filepath.Join("test-data", "configs", shortName+".yaml")
+	expected, err := os.ReadFile(file)
+	require.NoError(t, err, "reading file: %s", file)
+	require.Equal(t, string(expected), string(got))
+}
+
+func TestImageConfigMods(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		state    func(testRunner) llb.State
+		skipMoby bool
+	}{{
+		name: "merge",
+		state: func(r testRunner) llb.State {
+			a := alpine(r).File(llb.Mkfile("/file1", 0o644, []byte("file1")))
+			b := llb.Scratch().File(llb.Mkfile("/file2", 0o644, []byte("file2")))
+			return llblib.Merge([]llb.State{a, b})
+		},
+		skipMoby: true,
+	}, {
+		name: "diff",
+		state: func(r testRunner) llb.State {
+			alpine := alpine(r)
+			added := alpine.File(llb.Mkfile("/file1", 0o644, []byte("file1")))
+			return llblib.Diff(alpine, added, llb.LinuxAmd64)
+		},
+		skipMoby: true,
+	}, {
+		name: "run",
+		state: func(r testRunner) llb.State {
+			return llblib.Run(alpine(r), llb.Shlex("echo hello")).Root()
+		},
+	}, {
+		name: "applyRun",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.ApplyRun(llb.Shlex("echo hello")),
+			)
+		},
+	}, {
+		name: "copy",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.Copy(
+					llb.Scratch().File(llb.Mkfile("/file1", 0o644, []byte("file1"))),
+					"/file1",
+					"/copied",
+				),
+			)
+		},
+	}, {
+		name: "defaultDir",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.DefaultDir("/tmp"),
+			)
+		},
+	}, {
+		name: "defaultUser",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.DefaultUser("nobody"),
+			)
+		},
+	}, {
+		name: "defaultEnv",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.AddDefaultEnv("A", "one"),
+				llblib.AddDefaultEnv("B", "two"),
+			)
+		},
+	}, {
+		name: "entrypoint",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.Entrypoint("/bin/true"),
+			)
+		},
+	}, {
+		name: "cmd",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.Cmd("/bin/true"),
+			)
+		},
+	}, {
+		name: "label",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.AddLabel("A", "one"),
+				llblib.AddLabel("B", "two"),
+			)
+		},
+	}, {
+		name: "exposePort",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.AddExposedPort("80/tcp"),
+			)
+		},
+	}, {
+		name: "addVolume",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.AddVolume("/some/cache"),
+			)
+		},
+	}, {
+		name: "stopsignal",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.StopSignal("SIGUSR1"),
+			)
+		},
+	}, {
+		name: "healthcheck",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.DockerHealthcheck(v1.HealthcheckConfig{
+					Test:        []string{"CMD", "/bin/true"},
+					Interval:    10 * time.Minute,
+					Timeout:     5 * time.Second,
+					StartPeriod: time.Minute,
+					Retries:     3,
+				}),
+			)
+		},
+	}, {
+		name: "onbuild",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.AddDockerOnBuild("RUN echo hello"),
+			)
+		},
+	}, {
+		name: "runshell",
+		state: func(r testRunner) llb.State {
+			return alpine(r).With(
+				llblib.DockerRunShell("/bin/bash -c"),
+			)
+		},
+	}} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := newTestRunner(t, withTimeout(60*time.Second))
+			if tt.skipMoby && r.isMoby {
+				t.Skip("skipping test because moby doesn't support the operation")
+			}
+			req := r.Solver.Build(tt.state(r))
+			resp, err := r.Run(t, req)
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.ExporterResponse[llblib.ExporterImageConfigKey])
+			expectConfig(t, resp.ExporterResponse[llblib.ExporterImageConfigKey])
+		})
+	}
+}

--- a/test-data/configs/addVolume.yaml
+++ b/test-data/configs/addVolume.yaml
@@ -1,0 +1,24 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    Volumes:
+        /some/cache: {}
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: VOLUME /some/cache
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/applyRun.yaml
+++ b/test-data/configs/applyRun.yaml
@@ -1,0 +1,21 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: RUN echo hello
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/cmd.yaml
+++ b/test-data/configs/cmd.yaml
@@ -1,0 +1,22 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/true
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: CMD ["/bin/true"]
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/copy.yaml
+++ b/test-data/configs/copy.yaml
@@ -1,0 +1,21 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: COPY 44313730cf537c6f661eaa430c6b9124a51343553ae19520d9436cc5d7339988:/file1 /copied
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/defaultDir.yaml
+++ b/test-data/configs/defaultDir.yaml
@@ -1,0 +1,23 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    WorkingDir: /tmp
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: WORKDIR /tmp
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/defaultEnv.yaml
+++ b/test-data/configs/defaultEnv.yaml
@@ -1,0 +1,24 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - A=one
+        - B=two
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: ENV A=one B=two
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/defaultUser.yaml
+++ b/test-data/configs/defaultUser.yaml
@@ -1,0 +1,23 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    User: nobody
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: USER nobody
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/diff.yaml
+++ b/test-data/configs/diff.yaml
@@ -1,0 +1,16 @@
+architecture: amd64
+config: {}
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: DIFF 543a865260facdb8281a70d1524fa666461dfd347d9e07516dba5b2045f347c8:/ eb8b43fcd3f7eaaf8c5510b69f68d6418b08d5231210b0e730a3407cc0fb68b5:/
+os: linux
+rootfs:
+    diff_ids: null
+    type: ""

--- a/test-data/configs/entrypoint.yaml
+++ b/test-data/configs/entrypoint.yaml
@@ -1,0 +1,24 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Entrypoint:
+        - /bin/true
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: ENTRYPOINT ["/bin/true"]
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/exposePort.yaml
+++ b/test-data/configs/exposePort.yaml
@@ -1,0 +1,24 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    ExposedPorts:
+        80/tcp: {}
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: EXPOSE 80/tcp
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/healthcheck.yaml
+++ b/test-data/configs/healthcheck.yaml
@@ -1,0 +1,30 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    Healthcheck:
+        Interval: 6e+11
+        Retries: 3
+        StartPeriod: 6e+10
+        Test:
+            - CMD
+            - /bin/true
+        Timeout: 5e+09
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: HEALTHCHECK {"Test":["CMD","/bin/true"],"Interval":600000000000,"Timeout":5000000000,"StartPeriod":60000000000,"Retries":3}
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/label.yaml
+++ b/test-data/configs/label.yaml
@@ -1,0 +1,25 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    Labels:
+        A: one
+        B: two
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: LABEL A=one B=two
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/merge.yaml
+++ b/test-data/configs/merge.yaml
@@ -1,0 +1,21 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: MERGE eb8b43fcd3f7eaaf8c5510b69f68d6418b08d5231210b0e730a3407cc0fb68b5:/ 65902131a50c5e81b3a32a22390bb23254da03fef796b33f93cd6d8ca99e51a8:/
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/onbuild.yaml
+++ b/test-data/configs/onbuild.yaml
@@ -1,0 +1,24 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    OnBuild:
+        - RUN echo hello
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: ONBUILD RUN echo hello
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/run.yaml
+++ b/test-data/configs/run.yaml
@@ -1,0 +1,21 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: RUN echo hello
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/runshell.yaml
+++ b/test-data/configs/runshell.yaml
@@ -1,0 +1,24 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    Shell:
+        - /bin/bash -c
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: SHELL ["/bin/bash -c"]
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/configs/stopsignal.yaml
+++ b/test-data/configs/stopsignal.yaml
@@ -1,0 +1,23 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    StopSignal: SIGUSR1
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: STOPSIGNAL SIGUSR1
+      empty_layer: true
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers

--- a/test-data/mounts.yaml
+++ b/test-data/mounts.yaml
@@ -1,7 +1,7 @@
 - type: EXEC
   args: [/bin/true]
-  env: [FOO=BAR]
-  cwd: /
+  env: ['PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', GOLANG_VERSION=1.20.1, GOPATH=/go, FOO=BAR]
+  cwd: /go
   extra-hosts:
     - {host: home, ip: 127.0.0.1}
   security-mode: INSECURE

--- a/test-data/propagated.yaml
+++ b/test-data/propagated.yaml
@@ -2,8 +2,8 @@
   input: &ref2
     type: EXEC
     args: [/bin/false]
-    env: [FOO=BAZ]
-    cwd: /
+    env: ['PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', GOLANG_VERSION=1.20.1, GOPATH=/go, FOO=BAZ]
+    cwd: /go
     mounts:
         - mountpoint: /
           type: BIND
@@ -11,8 +11,8 @@
           input:
             type: EXEC
             args: [/bin/true]
-            env: [FOO=BAR]
-            cwd: /
+            env: ['PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', GOLANG_VERSION=1.20.1, GOPATH=/go, FOO=BAR]
+            cwd: /go
             mounts:
                 - mountpoint: /
                   type: BIND

--- a/test-data/run.yaml
+++ b/test-data/run.yaml
@@ -1,6 +1,7 @@
 - type: EXEC
   args: [/bin/true]
-  cwd: /
+  env: ['PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', GOLANG_VERSION=1.20.1, GOPATH=/go]
+  cwd: /go
   mounts:
     - mountpoint: /
       type: BIND

--- a/test-data/runs.yaml
+++ b/test-data/runs.yaml
@@ -1,7 +1,8 @@
 # good build
 - type: EXEC
   args: [/bin/true]
-  cwd: /
+  env: ['PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', GOLANG_VERSION=1.20.1, GOPATH=/go]
+  cwd: /go
   mounts:
     - mountpoint: /
       type: BIND
@@ -13,7 +14,8 @@
 # bad build
 - type: EXEC
   args: [/bin/false]
-  cwd: /
+  env: ['PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', GOLANG_VERSION=1.20.1, GOPATH=/go]
+  cwd: /go
   mounts:
     - mountpoint: /
       type: BIND


### PR DESCRIPTION
add docker and oci image config options (label, user, etc)
add llb wrappers that will also update image config data:
  * Image, Merge, Diff, Run, Copy

standardized import names:
  * ocispec "github.com/opencontainers/image-spec/specs-go/v1"
  * mdispec "github.com/moby/docker-image-spec/specs-go/v1"
 
client creation now returns `isMoby` bool if the buildkit client is connected to local docker daemon.  There are some differences in export logic for buildkit-in-moby vs vanilla buildkit.  Also merge/diff op is not supported in moby, so we skip those tests.