### PR TITLE
several small changes for general and dockerfile usage

### DIFF
--- a/context.go
+++ b/context.go
@@ -13,6 +13,7 @@ type (
 	progressKey      struct{}
 	sessionKey       struct{}
 	imageResolverKey struct{}
+	sessionIDKey     struct{}
 	envKey           string
 )
 
@@ -50,6 +51,18 @@ func (p nullProgress) Channel(opts ...progress.ChannelOption) chan *client.Solve
 		}
 	}()
 	return ch
+}
+
+func withSessionID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, id)
+}
+
+func sessionID(ctx context.Context) string {
+	t, ok := ctx.Value(sessionIDKey{}).(string)
+	if !ok {
+		return ""
+	}
+	return t
 }
 
 // WithSession returns a context with the provided session stored.

--- a/docker.go
+++ b/docker.go
@@ -104,7 +104,19 @@ func directSolve(ctx context.Context, dockerfile []byte, opts DockerfileOpts) (l
 	if err != nil {
 		return llb.Scratch(), errtrace.Wrap(err)
 	}
-	return withImageConfig(*state, img), nil
+	var history []History
+	for _, h := range img.History {
+		history = append(history, History{History: h})
+	}
+	imageConfig := ImageConfig{
+		DockerOCIImage: *img,
+		ContainerConfig: ContainerConfig{
+			Cmd:    img.Config.Cmd,
+			Labels: img.Config.Labels,
+		},
+		History: history,
+	}
+	return withImageConfig(*state, &imageConfig), nil
 }
 
 const (

--- a/docker.go
+++ b/docker.go
@@ -53,9 +53,9 @@ func WithBuildArg(k, v string) DockerfileOption {
 }
 
 // WithTargetPlatform will set the platform for the Dockerfile build.
-func WithTargetPlatform(p *ocispec.Platform) DockerfileOption {
+func WithTargetPlatform(p ocispec.Platform) DockerfileOption {
 	return dockerfileOptionFunc(func(o *dockerfileOpts) {
-		o.TargetPlatform = p
+		o.TargetPlatform = &p
 	})
 }
 

--- a/docker.go
+++ b/docker.go
@@ -19,6 +19,7 @@ type DockerfileOpts = dockerfile2llb.ConvertOpt
 type dockerfileOpts struct {
 	DockerfileOpts
 	buildContexts map[string]llb.State
+	frontendOpts  map[string]string
 }
 
 // DockerfileOption can be used to modify a Dockerfile request.
@@ -42,13 +43,16 @@ func WithTarget(t string) DockerfileOption {
 // WithBuildArg can be used to set build args for the Dockerfile build.
 func WithBuildArg(k, v string) DockerfileOption {
 	return dockerfileOptionFunc(func(o *dockerfileOpts) {
-		if o.BuildArgs == nil {
-			o.BuildArgs = map[string]string{
-				k: v,
-			}
-			return
-		}
 		o.BuildArgs[k] = v
+	})
+}
+
+// WithBuildArgs can be used to set build args for the Dockerfile build.
+func WithBuildArgs(args map[string]string) DockerfileOption {
+	return dockerfileOptionFunc(func(o *dockerfileOpts) {
+		for k, v := range args {
+			o.BuildArgs[k] = v
+		}
 	})
 }
 
@@ -63,13 +67,38 @@ func WithTargetPlatform(p ocispec.Platform) DockerfileOption {
 // build.
 func WithBuildContext(name string, st llb.State) DockerfileOption {
 	return dockerfileOptionFunc(func(o *dockerfileOpts) {
-		if o.buildContexts == nil {
-			o.buildContexts = map[string]llb.State{
-				name: st,
-			}
+		o.buildContexts[name] = st
+	})
+}
+
+// WithRemoteBuildContext will set an additional build context for the Dockerfile
+// build from a remote source.  Examples:
+//
+//   - git repo:
+//     llblib.WithRemoveBuildContext("my-repo", "https://github.com/myorg/my-repo.git")
+//
+//   - url:
+//     llblib.WithRemoveBuildContext("my-url", "https://example.com/my-url/README.md")
+//
+//   - docker image:
+//     llblib.WithRemoveBuildContext("my-image", "docker-image://myorg/my-image:latest")
+//
+//   - target from the Dockerfile being built:
+//     llblib.WithRemoveBuildContext("my-target", "target:my-target")
+func WithRemoteBuildContext(name string, src string) DockerfileOption {
+	return dockerfileOptionFunc(func(o *dockerfileOpts) {
+		o.frontendOpts["context:"+name] = src
+	})
+}
+
+// WithDockerfileName will set the name of the Dockerfile to use for the build.
+// This is to make the build output consistent with a user provided filename.
+func WithDockerfileName(name string) DockerfileOption {
+	return dockerfileOptionFunc(func(o *dockerfileOpts) {
+		if name == defaultDockerfileName {
 			return
 		}
-		o.buildContexts[name] = st
+		o.frontendOpts["filename"] = name
 	})
 }
 
@@ -83,7 +112,13 @@ func Dockerfile(dockerfile []byte, buildContext llb.State, opts ...DockerfileOpt
 				LLBCaps:      &caps,
 				MetaResolver: LoadImageResolver(ctx),
 				MainContext:  &buildContext,
+				Config: dockerui.Config{
+					BuildArgs: map[string]string{},
+				},
 			},
+
+			buildContexts: map[string]llb.State{},
+			frontendOpts:  map[string]string{},
 		}
 		for _, opt := range opts {
 			opt.SetDockerfileOption(&docOpts)
@@ -91,7 +126,7 @@ func Dockerfile(dockerfile []byte, buildContext llb.State, opts ...DockerfileOpt
 		if source, _, _, ok := parser.DetectSyntax(dockerfile); ok {
 			return errtrace.Wrap2(frontendDockerfileSolve(source, dockerfile, docOpts))
 		}
-		if len(docOpts.buildContexts) > 0 {
+		if len(docOpts.buildContexts) > 0 || len(docOpts.frontendOpts) > 0 {
 			// we cannot use the direct solve if we have additional inputs
 			return errtrace.Wrap2(frontendDockerfileSolve("dockerfile.v0", dockerfile, docOpts))
 		}
@@ -133,13 +168,28 @@ func frontendDockerfileSolve(
 	dockerfile []byte,
 	opts dockerfileOpts,
 ) (llb.State, error) {
+	filename := defaultDockerfileName
+	if name, ok := opts.frontendOpts["filename"]; ok {
+		filename = name
+	}
+
+	var fileAction *llb.FileAction
+	dir := path.Clean(path.Dir(filename))
+	if dir != "." {
+		fileAction = llb.Mkdir(dir, 0o755, llb.WithParents(true)).Mkfile(filename, 0o644, dockerfile)
+	} else {
+		fileAction = llb.Mkfile(filename, 0o644, dockerfile)
+	}
+
 	feOpts := []FrontendOption{
-		FrontendInput(dockerui.DefaultLocalNameDockerfile, llb.Scratch().File(
-			llb.Mkfile(defaultDockerfileName, 0o644, dockerfile),
-		)),
+		FrontendInput(dockerui.DefaultLocalNameDockerfile, llb.Scratch().File(fileAction, llb.WithCustomName("load build definition from "+filename))),
 	}
 	if opts.MainContext != nil {
 		feOpts = append(feOpts, FrontendInput(dockerui.DefaultLocalNameContext, *opts.MainContext))
+	}
+
+	for name, value := range opts.frontendOpts {
+		feOpts = append(feOpts, FrontendOpt(name, value))
 	}
 
 	for name, state := range opts.buildContexts {

--- a/docker_test.go
+++ b/docker_test.go
@@ -36,7 +36,7 @@ func TestDockerfile(t *testing.T) {
 		[]byte(dockerfile),
 		llb.Scratch(),
 		llblib.WithTarget("download"),
-		llblib.WithTargetPlatform(&linux),
+		llblib.WithTargetPlatform(linux),
 	)
 
 	tdir := t.TempDir()
@@ -80,7 +80,7 @@ RUN false # <- should not run
 		[]byte(dockerfile),
 		llb.Scratch(),
 		llblib.WithTarget("download"),
-		llblib.WithTargetPlatform(&linux),
+		llblib.WithTargetPlatform(linux),
 		llblib.WithBuildArg("MSG", "custom"),
 	)
 
@@ -135,14 +135,14 @@ func TestDockerfileBuildContexts(t *testing.T) {
 	st1 := llblib.Dockerfile(
 		[]byte(dockerfile1),
 		llb.Scratch().File(llb.Mkfile("file1", 0o644, nil)),
-		llblib.WithTargetPlatform(&linux),
+		llblib.WithTargetPlatform(linux),
 		llblib.WithBuildContext("extra", r.Solver.Local(tdir)),
 	)
 
 	st := llblib.Dockerfile(
 		[]byte(dockerfile2),
 		llb.Scratch().File(llb.Mkfile("file3", 0o644, nil)),
-		llblib.WithTargetPlatform(&linux),
+		llblib.WithTargetPlatform(linux),
 		llblib.WithBuildContext("extra", st1),
 	)
 
@@ -178,7 +178,7 @@ func TestDockerfileRunMounts(t *testing.T) {
 	st := llblib.Dockerfile(
 		[]byte(dockerfile),
 		llb.Scratch(),
-		llblib.WithTargetPlatform(&linux),
+		llblib.WithTargetPlatform(linux),
 		llblib.WithBuildContext("my.input", r.Solver.Local(inputDir)),
 		llblib.WithBuildContext("my.cache", r.Solver.Local(inputDir)),
 	)

--- a/dockerload.go
+++ b/dockerload.go
@@ -22,10 +22,8 @@ func DockerSave(ref reference.Reference, output io.WriteCloser) RequestOption {
 				"name": ref.String(),
 			},
 		})
-		r.attachables = append(r.attachables,
-			filesync.NewFSSyncTarget(
-				filesync.WithFSSync(exportIndex, outputFunc),
-			),
+		r.download = filesync.NewFSSyncTarget(
+			filesync.WithFSSync(exportIndex, outputFunc),
 		)
 	})
 }

--- a/examples/docker/main.go
+++ b/examples/docker/main.go
@@ -33,7 +33,7 @@ func main() {
 	context := llb.Scratch().File(llb.Mkfile("foobar", 0o644, []byte("something")))
 
 	root := llblib.Dockerfile([]byte(dockerfile), context,
-		llblib.WithTargetPlatform(&p),
+		llblib.WithTargetPlatform(p),
 	)
 
 	req := slv.Container(root,

--- a/examples/fail/main.go
+++ b/examples/fail/main.go
@@ -33,8 +33,8 @@ func main() {
 	}
 
 	p := llblib.Persistent(root, mounts)
-	p.Run(llb.Shlex("touch /scratch/scratch-foobar"), llblib.IgnoreCache())
-	p.Run(llb.Shlex("touch /src/src-foobar"), llblib.IgnoreCache())
+	p.Run(llb.Shlex("touch /scratch/scratch-foobar"), llblib.IgnoreCache)
+	p.Run(llb.Shlex("touch /src/src-foobar"), llblib.IgnoreCache)
 	p.Run(llb.Shlex("false")) // <- trigger /bin/bash on error
 
 	scratch, ok := p.GetMount("/scratch")

--- a/examples/forward/main.go
+++ b/examples/forward/main.go
@@ -37,7 +37,7 @@ func main() {
 		llblib.Run(root,
 			llb.Shlex("curl -sf --unix /tmp/forward.sock -v http://unix -o /tmp/special"),
 			slv.Forward("tcp://127.0.0.1:1234", "/tmp/forward.sock"),
-			llblib.IgnoreCache(),
+			llblib.IgnoreCache,
 		).Run(
 			llb.Args([]string{"sh", "-c", `test "$(cat /tmp/special)" = "message-from-host"`}),
 		).Root(),

--- a/frontend.go
+++ b/frontend.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
-	mdispec "github.com/moby/docker-image-spec/specs-go/v1"
 )
 
 // FrontendOption can be used to modify a Frontend request.
@@ -151,10 +150,13 @@ func Frontend(source string, opts ...FrontendOption) llb.State {
 						}
 						// we need to parse the document again bc WithImageConfig
 						// does not apply the USER config.
-						var img mdispec.DockerOCIImage
+						var img ImageConfig
 						if err := json.Unmarshal(config, &img); err != nil {
 							return nil, errtrace.Errorf("failed to parse config from frontend request: %w", err)
 						}
+						img.ContainerConfig.Cmd = img.DockerOCIImage.Config.Cmd
+						img.ContainerConfig.Labels = img.DockerOCIImage.Config.Labels
+
 						result = withImageConfig(result, &img)
 						if img.Config.User != "" {
 							result = result.User(img.Config.User)

--- a/progress/fromreader.go
+++ b/progress/fromreader.go
@@ -26,16 +26,18 @@ func FromReader(p Progress, name string, rc io.ReadCloser) {
 	ch := p.Channel()
 	defer close(ch)
 
+	// copy before send to avoid parallel updates to our vertex pointer
+	vtx2 := vtx
+
 	ch <- &client.SolveStatus{
 		Vertexes: []*client.Vertex{&vtx},
 	}
 
-	tm2 := time.Now()
-	vtx2 := vtx
-	vtx2.Completed = &tm2
 	if _, err := io.Copy(io.Discard, rc); err != nil {
 		vtx2.Error = err.Error()
 	}
+	tm2 := time.Now()
+	vtx2.Completed = &tm2
 	ch <- &client.SolveStatus{
 		Vertexes: []*client.Vertex{&vtx2},
 	}

--- a/push_test.go
+++ b/push_test.go
@@ -126,7 +126,7 @@ func TestRegistryPushDockerfile(t *testing.T) {
 		[]byte(dockerfile),
 		llb.Scratch(),
 		llblib.WithTarget("download"),
-		llblib.WithTargetPlatform(&currentPlatform),
+		llblib.WithTargetPlatform(currentPlatform),
 	)
 
 	req := r.Solver.Build(

--- a/run.go
+++ b/run.go
@@ -23,8 +23,20 @@ func (ro RunOptions) SetRunOption(ei *llb.ExecInfo) {
 // prevent any cache from being written from the state, so the Run operation
 // will be executed multiple times within a session if the session evaluates the
 // same vertex multiple times.
-func IgnoreCache() llb.RunOption {
-	return llb.AddEnv("LLBLIB_IGNORE_CACHE", identity.NewID())
+var IgnoreCache = ignoreCache{}
+
+type ignoreCache struct{}
+
+func (ignoreCache) SetRunOption(ei *llb.ExecInfo) {
+	llb.AddEnv("LLBLIB_IGNORE_CACHE", identity.NewID()).SetRunOption(ei)
+}
+
+func (ignoreCache) SetDockerfileOption(do *dockerfileOpts) {
+	do.frontendOpts["no-cache"] = ""
+}
+
+func (ignoreCache) SetFrontendOption(fo *frontendOptions) {
+	fo.Opts["no-cache"] = ""
 }
 
 type copyOptionFunc func(*llb.CopyInfo)

--- a/session.go
+++ b/session.go
@@ -88,7 +88,8 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 		AllowedEntitlements:   req.entitlements,
 	}
 
-	ctx = WithProgress(ctx, s.progress)
+	prog := s.progress.Label(req.Label)
+	ctx = WithProgress(ctx, prog)
 	ctx = WithSession(ctx, s)
 
 	if req.buildFunc != nil {
@@ -102,7 +103,7 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 				return nil, errors.Join(err, errtrace.Wrap(moreErr))
 			}
 			return res, errtrace.Wrap(err)
-		}, s.progress.Channel(progress.AddLabel(req.Label)))
+		}, prog.Channel())
 		if err != nil {
 			return nil, errtrace.Errorf("build failed: %w", err)
 		}
@@ -158,7 +159,7 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 			}
 		}
 		return res, errtrace.Wrap(err)
-	}, s.progress.Channel(progress.AddLabel(req.Label)))
+	}, prog.Channel())
 	if err != nil {
 		return nil, errtrace.Errorf("solve failed: %w", err)
 	}

--- a/session.go
+++ b/session.go
@@ -91,6 +91,7 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 	prog := s.progress.Label(req.Label)
 	ctx = WithProgress(ctx, prog)
 	ctx = WithSession(ctx, s)
+	ctx = withSessionID(ctx, sess.ID())
 
 	if req.buildFunc != nil {
 		res, err := s.client.Build(ctx, solveOpt, "llblib", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {

--- a/state.go
+++ b/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	mdispec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/exp/maps"
 )
 
 // Digest returns the digest for the state.
@@ -301,6 +303,18 @@ func AddLabel(key, value string) llb.StateOption {
 			commitHistoryKV(ctx, img, "LABEL", key, value)
 			return nil
 		})
+	}
+}
+
+// AddLabels records a LABEL to the image config.
+func AddLabels(labels map[string]string) llb.StateOption {
+	return func(st llb.State) llb.State {
+		keys := maps.Keys(labels)
+		sort.Strings(keys)
+		for _, key := range keys {
+			st = AddLabel(key, labels[key])(st)
+		}
+		return st
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -24,20 +24,45 @@ func Digest(st llb.State) (digest.Digest, error) {
 }
 
 type layerHistory struct {
-	empty bool
-	desc  string
+	empty     bool
+	desc      string
+	sessionID string
 }
 
-func commitHistory(img *mdispec.DockerOCIImage, commit layerHistory) {
-	img.History = append(img.History, ocispec.History{
-		// Set a zero value on Created for more reproducible builds
-		Created:    &time.Time{},
-		CreatedBy:  commit.desc,
-		Comment:    "llblib.v0",
-		EmptyLayer: commit.empty,
+func commitHistory(img *ImageConfig, commit layerHistory) {
+	img.History = append(img.History, History{
+		History: ocispec.History{
+			// Set a zero value on Created for more reproducible builds
+			Created:    &time.Time{},
+			CreatedBy:  commit.desc,
+			Comment:    "llblib.v0",
+			EmptyLayer: commit.empty,
+		},
+		sessionID: commit.sessionID,
 	})
 	// Set a zero value on Created for more reproducible builds
 	img.Created = &time.Time{}
+}
+
+// commitHistoryKV will add key/value instructions to the image history, if
+// the most recent history record is for the same instruction and created within
+// the current session then we will append the key/value to the existing record.
+func commitHistoryKV(ctx context.Context, img *ImageConfig, instruction, key, value string) {
+	// In Dockerfile for some instructions (ENV, LABEL) multiple values can be
+	// specified in one instruction leading to one history element.  This checks
+	// if the previous history committed was also the same instruction, in which
+	// case it should just add to the previous history element.
+	sessID := sessionID(ctx)
+	numHistory := len(img.History)
+	if numHistory > 0 && strings.HasPrefix(img.History[numHistory-1].CreatedBy, instruction) && img.History[numHistory-1].sessionID == sessID {
+		img.History[numHistory-1].CreatedBy += " " + shellquote.Join(key) + "=" + shellquote.Join(value)
+	} else {
+		commitHistory(img, layerHistory{
+			empty:     true,
+			desc:      instruction + " " + shellquote.Join(key) + "=" + shellquote.Join(value),
+			sessionID: sessID,
+		})
+	}
 }
 
 // Merge is similar to llb.Merge but also commits history to the image config.
@@ -72,7 +97,7 @@ func Merge(states []llb.State, opts ...llb.ConstraintsOpt) llb.State {
 			msgs = append(msgs, dgst.Encoded()+":/")
 		}
 
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			commitHistory(img, layerHistory{
 				empty: false,
 				desc:  "MERGE " + strings.Join(msgs, " "),
@@ -93,13 +118,16 @@ func Diff(lower, upper llb.State, opts ...llb.ConstraintsOpt) llb.State {
 		if err != nil {
 			return llb.State{}, errtrace.Wrap(err)
 		}
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Author = ""
 			img.RootFS = ocispec.RootFS{}
 			img.Config = mdispec.DockerOCIImageConfig{
 				ImageConfig: ocispec.ImageConfig{
 					Labels: img.Config.Labels,
 				},
+			}
+			img.ContainerConfig = ContainerConfig{
+				Labels: img.ContainerConfig.Labels,
 			}
 
 			commitHistory(img, layerHistory{
@@ -123,7 +151,7 @@ func Run(st llb.State, opts ...llb.RunOption) llb.ExecState {
 		if err != nil {
 			return llb.State{}, fmt.Errorf("failed to get args from state for history: %w", err)
 		}
-		return withImageConfigMutator(st, func(ctx context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(ctx context.Context, img *ImageConfig) error {
 			commitHistory(img, layerHistory{
 				empty: false,
 				desc:  "RUN " + shellquote.Join(args...),
@@ -159,7 +187,7 @@ func Copy(src llb.State, srcPath, destPath string, opts ...llb.CopyOption) llb.S
 			if err != nil {
 				return llb.State{}, errtrace.Wrap(err)
 			}
-			return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+			return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 				commitHistory(img, layerHistory{
 					empty: false,
 					desc:  shellquote.Join("COPY", dgst.Encoded()+":"+srcPath, destPath),
@@ -175,7 +203,7 @@ func Copy(src llb.State, srcPath, destPath string, opts ...llb.CopyOption) llb.S
 func DefaultDir(d string) llb.StateOption {
 	return func(st llb.State) llb.State {
 		st = st.Dir(d)
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.WorkingDir = d
 			commitHistory(img, layerHistory{
 				empty: true,
@@ -191,7 +219,7 @@ func DefaultDir(d string) llb.StateOption {
 func DefaultUser(u string) llb.StateOption {
 	return func(st llb.State) llb.State {
 		st = st.User(u)
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.User = u
 			commitHistory(img, layerHistory{
 				empty: true,
@@ -207,21 +235,9 @@ func DefaultUser(u string) llb.StateOption {
 func AddDefaultEnv(key, value string) llb.StateOption {
 	return func(st llb.State) llb.State {
 		st = st.AddEnv(key, value)
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(ctx context.Context, img *ImageConfig) error {
 			img.Config.Env = append(img.Config.Env, key+"="+value)
-			// In Dockerfile, multiple ENV can be specified in the same ENV command
-			// leading to one history element. This checks if the previous history
-			// committed was also an ENV, in which case it should just add to the
-			// previous history element.
-			numHistory := len(img.History)
-			if numHistory > 0 && strings.HasPrefix(img.History[numHistory-1].CreatedBy, "ENV") {
-				img.History[numHistory-1].CreatedBy += " " + shellquote.Join(key) + "=" + shellquote.Join(value)
-			} else {
-				commitHistory(img, layerHistory{
-					empty: true,
-					desc:  "ENV " + shellquote.Join(key) + "=" + shellquote.Join(value),
-				})
-			}
+			commitHistoryKV(ctx, img, "ENV", key, value)
 			return nil
 		})
 	}
@@ -230,7 +246,7 @@ func AddDefaultEnv(key, value string) llb.StateOption {
 // Entrypoint records the ENTRYPOINT to image config.
 func Entrypoint(entrypoint ...string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.Entrypoint = entrypoint
 			out, err := json.Marshal(entrypoint)
 			if err != nil {
@@ -248,8 +264,9 @@ func Entrypoint(entrypoint ...string) llb.StateOption {
 // Cmd records the CMD command arguments to the image config.
 func Cmd(cmd ...string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.Cmd = cmd
+			img.ContainerConfig.Cmd = cmd // legacy
 			out, err := json.Marshal(cmd)
 			if err != nil {
 				return fmt.Errorf("failed to marshal CMD as json: %w", err)
@@ -266,9 +283,12 @@ func Cmd(cmd ...string) llb.StateOption {
 // AddLabel records a LABEL to the image config.
 func AddLabel(key, value string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(ctx context.Context, img *ImageConfig) error {
 			if img.Config.Labels == nil {
 				img.Config.Labels = make(map[string]string)
+			}
+			if img.ContainerConfig.Labels == nil {
+				img.ContainerConfig.Labels = make(map[string]string)
 			}
 
 			if curVal, ok := img.Config.Labels[key]; ok && curVal == value {
@@ -277,20 +297,8 @@ func AddLabel(key, value string) llb.StateOption {
 			}
 
 			img.Config.Labels[key] = value
-
-			// In Dockerfile, multiple labels can be specified in the same LABEL command
-			// leading to one history element. This checks if the previous history
-			// committed was also a label, in which case it should just add to the
-			// previous history element.
-			numHistory := len(img.History)
-			if numHistory > 0 && strings.HasPrefix(img.History[numHistory-1].CreatedBy, "LABEL") {
-				img.History[numHistory-1].CreatedBy += " " + shellquote.Join(key) + "=" + shellquote.Join(value)
-			} else {
-				commitHistory(img, layerHistory{
-					empty: true,
-					desc:  "LABEL " + shellquote.Join(key) + "=" + shellquote.Join(value),
-				})
-			}
+			img.ContainerConfig.Labels[key] = value // legacy
+			commitHistoryKV(ctx, img, "LABEL", key, value)
 			return nil
 		})
 	}
@@ -299,7 +307,7 @@ func AddLabel(key, value string) llb.StateOption {
 // AddExposedPort records an EXPOSE port to the image config.
 func AddExposedPort(port string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			if img.Config.ExposedPorts == nil {
 				img.Config.ExposedPorts = make(map[string]struct{})
 			}
@@ -320,7 +328,7 @@ func AddExposedPort(port string) llb.StateOption {
 // AddVolume records a VOLUME to the image config.
 func AddVolume(mountpoint string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			if img.Config.Volumes == nil {
 				img.Config.Volumes = make(map[string]struct{})
 			}
@@ -341,7 +349,7 @@ func AddVolume(mountpoint string) llb.StateOption {
 // StopSignal records the STOPSIGNAL to the image config.
 func StopSignal(signal string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.StopSignal = signal
 			commitHistory(img, layerHistory{
 				empty: true,
@@ -355,7 +363,7 @@ func StopSignal(signal string) llb.StateOption {
 // DockerHealthcheck records the HEALTHCHECK configuration to the image config.
 func DockerHealthcheck(hc mdispec.HealthcheckConfig) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.Healthcheck = &hc
 			out, err := json.Marshal(hc)
 			if err != nil {
@@ -373,7 +381,7 @@ func DockerHealthcheck(hc mdispec.HealthcheckConfig) llb.StateOption {
 // AddDockerOnBuild records the ONBUILD instruction to the image config.
 func AddDockerOnBuild(instruction string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.OnBuild = append(img.Config.OnBuild, instruction)
 			commitHistory(img, layerHistory{
 				empty: true,
@@ -387,7 +395,7 @@ func AddDockerOnBuild(instruction string) llb.StateOption {
 // DockerRunShell sets the SHELL for the image config.
 func DockerRunShell(shell ...string) llb.StateOption {
 	return func(st llb.State) llb.State {
-		return withImageConfigMutator(st, func(_ context.Context, img *mdispec.DockerOCIImage) error {
+		return withImageConfigMutator(st, func(_ context.Context, img *ImageConfig) error {
 			img.Config.Shell = shell
 			out, err := json.Marshal(shell)
 			if err != nil {

--- a/test-data/configs/addVolume.yaml
+++ b/test-data/configs/addVolume.yaml
@@ -6,6 +6,13 @@ config:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     Volumes:
         /some/cache: {}
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/applyRun.yaml
+++ b/test-data/configs/applyRun.yaml
@@ -4,6 +4,13 @@ config:
         - /bin/sh
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/cmd.yaml
+++ b/test-data/configs/cmd.yaml
@@ -4,6 +4,10 @@ config:
         - /bin/true
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+container_config:
+    Cmd:
+        - /bin/true
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/copy.yaml
+++ b/test-data/configs/copy.yaml
@@ -4,6 +4,13 @@ config:
         - /bin/sh
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/defaultDir.yaml
+++ b/test-data/configs/defaultDir.yaml
@@ -5,6 +5,13 @@ config:
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     WorkingDir: /tmp
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/defaultEnv.yaml
+++ b/test-data/configs/defaultEnv.yaml
@@ -6,6 +6,13 @@ config:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         - A=one
         - B=two
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/defaultUser.yaml
+++ b/test-data/configs/defaultUser.yaml
@@ -5,6 +5,13 @@ config:
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     User: nobody
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/entrypoint.yaml
+++ b/test-data/configs/entrypoint.yaml
@@ -6,6 +6,13 @@ config:
         - /bin/true
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/exposePort.yaml
+++ b/test-data/configs/exposePort.yaml
@@ -6,6 +6,13 @@ config:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     ExposedPorts:
         80/tcp: {}
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/healthcheck.yaml
+++ b/test-data/configs/healthcheck.yaml
@@ -12,6 +12,13 @@ config:
             - CMD
             - /bin/true
         Timeout: 5e+09
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/label.yaml
+++ b/test-data/configs/label.yaml
@@ -7,6 +7,15 @@ config:
     Labels:
         A: one
         B: two
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels:
+        A: one
+        B: two
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/onbuild.yaml
+++ b/test-data/configs/onbuild.yaml
@@ -6,6 +6,13 @@ config:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     OnBuild:
         - RUN echo hello
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/run.yaml
+++ b/test-data/configs/run.yaml
@@ -4,6 +4,13 @@ config:
         - /bin/sh
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/runshell.yaml
+++ b/test-data/configs/runshell.yaml
@@ -6,6 +6,13 @@ config:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     Shell:
         - /bin/bash -c
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/test-data/configs/stopsignal.yaml
+++ b/test-data/configs/stopsignal.yaml
@@ -5,6 +5,13 @@ config:
     Env:
         - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     StopSignal: SIGUSR1
+container_config:
+    Cmd:
+        - /bin/sh
+        - -c
+        - '#(nop) '
+        - CMD ["/bin/sh"]
+    Labels: {}
 created: "0001-01-01T00:00:00Z"
 history:
     - created: "2024-05-22T18:18:11.872913732Z"

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -146,7 +146,7 @@ func TestYAML(t *testing.T) {
 			`),
 			llb.Scratch(),
 			llblib.WithTarget("download"),
-			llblib.WithTargetPlatform(&ocispec.Platform{
+			llblib.WithTargetPlatform(ocispec.Platform{
 				OS: "linux", Architecture: "arm64",
 			}),
 		)),
@@ -161,7 +161,7 @@ func TestYAML(t *testing.T) {
 				RUN echo hi
 			`),
 			llb.Scratch(),
-			llblib.WithTargetPlatform(&ocispec.Platform{
+			llblib.WithTargetPlatform(ocispec.Platform{
 				OS: "linux", Architecture: "arm64",
 			}),
 		)),


### PR DESCRIPTION
* revert #23  - this didn't work when solving parallel requests with `Download`, I will add a test for this, I think we can also simplify the existing logic a bit.
* add `progress.Begin` to allow one-off messages to be printed to progress.
* add limited legacy schema1 `container_config` support for the image config
* added `WithLock` ContainerOption so we can prevent multiple parallel processes from taking over the TTY
* `WithTargetPlatform` should not take a pointer
* modify `IgnoreCache` to be a valid DockerfileOption, and FrontendOptions
* add `WithBuildArgs` helper that accepts a map
* add `WithRemoteBuildContext` which registered remote URLs (strings) as contexts in the solve.
* add `WithDockerFilename` to make build output what user expects when solving costing names (ie `docker build -f ./Dockerfile.foo`)
* fix issue where ImageResolver did not have docker auth handler registered when used outside of a session
* fix issue where the custom/modified image config was not being returned from the solve when the image was not exported
* add `AddLabels` helper that takes a map.

There are a pile of commits that are probably easier to review independently, I can split up the PR if desired.