### PR TITLE
add BuildDefinition and MarshalWithImageConfig

### DIFF
--- a/builddef_test.go
+++ b/builddef_test.go
@@ -1,0 +1,39 @@
+package llblib_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coryb/llblib"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromDefinition(t *testing.T) {
+	t.Parallel()
+	tdir := t.TempDir()
+
+	r := newTestRunner(t, withTimeout(10*time.Minute))
+
+	def, err := llblib.MarshalWithImageConfig(
+		context.Background(),
+		buildExample(r, llb.AddEnv("GOARCH", "amd64")),
+	)
+	require.NoError(t, err)
+
+	_, err = r.Run(t, r.Solver.Build(
+		llblib.BuildDefinition(def),
+		llblib.Download(filepath.Join(tdir, "build", "amd64")),
+		llblib.WithLabel("linux/amd64"),
+	))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(tdir, "build", "amd64", "build"))
+	require.NoError(t, err)
+	out, err := exec.Command("go", "version", "-m", filepath.Join(tdir, "build", "amd64", "build")).CombinedOutput()
+	require.NoError(t, err)
+	require.Contains(t, string(out), "GOARCH=amd64")
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/distribution/reference v0.5.0
 	github.com/docker/cli v25.0.3+incompatible
 	github.com/docker/docker v25.0.3+incompatible // master (v25.0.0-dev)
+	github.com/docker/go-connections v0.5.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/moby/buildkit v0.13.2
 	github.com/moby/docker-image-spec v1.3.1
@@ -27,8 +28,6 @@ require (
 	google.golang.org/grpc v1.59.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require github.com/docker/go-connections v0.5.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect

--- a/lint_test.go
+++ b/lint_test.go
@@ -1,7 +1,6 @@
 package llblib_test
 
 import (
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -29,9 +28,6 @@ func TestLint(t *testing.T) {
 	// 5m timeout b/c github actions can be slow to pull the golangci image
 	r := newTestRunner(t, withTimeout(300*time.Second))
 
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
 	currentPlatform := ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
@@ -44,8 +40,8 @@ func TestLint(t *testing.T) {
 		llb.Args([]string{"golangci-lint", "run", "--timeout", "9m"}),
 		// ensure go mod cache location is in our persistent cache dir
 		llb.AddEnv("GOMODCACHE", "/root/.cache/go-mod"),
-		llb.Dir(cwd),
-		llb.AddMount(cwd, goSource(r.Solver)),
+		llb.Dir(r.WorkDir),
+		llb.AddMount(r.WorkDir, goSource(r.Solver)),
 		llb.AddMount(
 			"/root/.cache",
 			llb.Scratch(),
@@ -56,6 +52,6 @@ func TestLint(t *testing.T) {
 		),
 	).Root()
 
-	_, err = r.Run(t, r.Solver.Build(st))
+	_, err := r.Run(t, r.Solver.Build(st))
 	require.NoError(t, err)
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,6 +1,7 @@
 package llblib_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -37,6 +38,11 @@ func expectConfig(t *testing.T, cfgData string) {
 
 func TestImageConfigMods(t *testing.T) {
 	t.Parallel()
+	def, err := llblib.MarshalWithImageConfig(
+		context.Background(),
+		llblib.Image(alpine, llb.LinuxAmd64),
+	)
+	require.NoError(t, err)
 	for _, tt := range []struct {
 		name string
 		base llb.State
@@ -64,6 +70,9 @@ func TestImageConfigMods(t *testing.T) {
 				),
 			)),
 		),
+	}, {
+		name: "def",
+		base: llblib.BuildDefinition(def),
 	}} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/test-data/def.yaml
+++ b/test-data/def.yaml
@@ -1,0 +1,62 @@
+- type: BUILD
+  inputs:
+    buildkit.llb.definition:
+        type: FILE
+        actions:
+            - type: MKFILE
+              path: /buildkit.llb.definition
+              mode: "0o644"
+              data: !!binary |
+                CkUaMQovZG9ja2VyLWltYWdlOi8vZG9ja2VyLmlvL2xpYnJhcnkvYnVzeWJveDpsYXRlc3
+                RSDgoFYW1kNjQSBWxpbnV4WgAKggIKSQpHc2hhMjU2OjA4YTAzZjNmZmU1ZmJhNDIxYTY0
+                MDNjMzFlMTUzNDI1Y2VkNjMxZDEwODg2OGYzMGUwNDk4NWY5OWQ2OTMyNmUSogEKOAoDY2
+                F0Cg4vdG1wL3VuaXguc29jaxIcU1NIX0FVVEhfU09DSz0vdG1wL3VuaXguc29jaxoBL1gB
+                EgMaAS8SYRoOL3RtcC91bml4LnNvY2swArIBTApHc2hhMjU2OjFiZTJlNGJiZDk1YWU5OT
+                IzZWNiYzkzOGMyNzI1OGRkMzQyNzA5ODhhODkyZjcyMTgxMTI4M2I1NDEwMTZiMmIggANS
+                DgoFYW1kNjQSBWxpbnV4WgAKSwpJCkdzaGEyNTY6Y2EzZDc4ZjI1YzRmNGVjM2I4MzYzZj
+                M1M2UzZDg0NTU3M2ZlYzBmMjg0ZGQ1YWMzYjYzZDI1YmE0Njc5NWRhNRLWAwpHc2hhMjU2
+                OjA4YTAzZjNmZmU1ZmJhNDIxYTY0MDNjMzFlMTUzNDI1Y2VkNjMxZDEwODg2OGYzMGUwND
+                k4NWY5OWQ2OTMyNmUSigMS9QIKEmxsYmxpYi5pbWFnZWNvbmZpZxLeAnsiY3JlYXRlZCI6
+                IjIwMjMtMDUtMThUMjI6MzQ6MTdaIiwiYXJjaGl0ZWN0dXJlIjoiYW1kNjQiLCJvcyI6Im
+                xpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6
+                ZDUxYWY5NmNmOTNlMjI1ODI1ZWZkNDg0ZWE0NTdmODY3Y2IyYjk2N2Y3NDE1YjlhM2I3ZT
+                Y1YTJmODAzODM4YSJdfSwiY29uZmlnIjp7IkNtZCI6WyJzaCJdfSwiY29udGFpbmVyX2Nv
+                bmZpZyI6eyJDbWQiOlsic2giXSwiTGFiZWxzIjp7fX0sImhpc3RvcnkiOlt7ImNyZWF0ZW
+                QiOiIyMDIzLTA1LTE4VDIyOjM0OjE3WiIsImNyZWF0ZWRfYnkiOiJCdXN5Qm94IDEuMzYu
+                MSAoZ2xpYmMpLCBEZWJpYW4gMTIifV19KhAKDHNvdXJjZS5pbWFnZRABEoEECkdzaGEyNT
+                Y6Y2EzZDc4ZjI1YzRmNGVjM2I4MzYzZjM1M2UzZDg0NTU3M2ZlYzBmMjg0ZGQ1YWMzYjYz
+                ZDI1YmE0Njc5NWRhNRK1AxL1AgoSbGxibGliLmltYWdlY29uZmlnEt4CeyJjcmVhdGVkIj
+                oiMjAyMy0wNS0xOFQyMjozNDoxN1oiLCJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoi
+                bGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Nj
+                pkNTFhZjk2Y2Y5M2UyMjU4MjVlZmQ0ODRlYTQ1N2Y4NjdjYjJiOTY3Zjc0MTViOWEzYjdl
+                NjVhMmY4MDM4MzhhIl19LCJjb25maWciOnsiQ21kIjpbInNoIl19LCJjb250YWluZXJfY2
+                9uZmlnIjp7IkNtZCI6WyJzaCJdLCJMYWJlbHMiOnt9fSwiaGlzdG9yeSI6W3siY3JlYXRl
+                ZCI6IjIwMjMtMDUtMThUMjI6MzQ6MTdaIiwiY3JlYXRlZF9ieSI6IkJ1c3lCb3ggMS4zNi
+                4xIChnbGliYyksIERlYmlhbiAxMiJ9XX0qEgoOZXhlYy5tZXRhLmJhc2UQASoTCg9leGVj
+                Lm1vdW50LmJpbmQQASoSCg5leGVjLm1vdW50LnNzaBABEoABCkdzaGEyNTY6ZDlmNjg3NT
+                RhZGM1ZjE4NzljNmY4NWFhZmEzYTQ0NzZlODYxODYxODNhNTFjOTBmMzQ0OWJiNTJiZDBm
+                NTU5ZBI1Kg8KC2NvbnN0cmFpbnRzEAEqFAoQbWV0YS5kZXNjcmlwdGlvbhABKgwKCHBsYX
+                Rmb3JtEAEamgEKSwpHc2hhMjU2OjA4YTAzZjNmZmU1ZmJhNDIxYTY0MDNjMzFlMTUzNDI1
+                Y2VkNjMxZDEwODg2OGYzMGUwNDk4NWY5OWQ2OTMyNmUSAApLCkdzaGEyNTY6Y2EzZDc4Zj
+                I1YzRmNGVjM2I4MzYzZjM1M2UzZDg0NTU3M2ZlYzBmMjg0ZGQ1YWMzYjYzZDI1YmE0Njc5
+                NWRhNRIA
+              input:
+                type: SOURCE
+                source: scratch
+  build:
+    type: EXEC
+    args: [cat, /tmp/unix.sock]
+    env: [SSH_AUTH_SOCK=/tmp/unix.sock]
+    cwd: /
+    mounts:
+        - mountpoint: /
+          type: BIND
+          output: 0
+          input:
+            type: SOURCE
+            source: docker-image://docker.io/library/busybox:latest
+            platform: linux/amd64
+        - mountpoint: /tmp/unix.sock
+          type: SSH
+          ssh: sha256:1be2e4bbd95ae9923ecbc938c27258dd34270988a892f721811283b541016b2b
+          mode: "0o600"

--- a/test_test.go
+++ b/test_test.go
@@ -33,6 +33,7 @@ type testRunner struct {
 	isMoby   bool
 	Solver   llblib.Solver
 	Progress progress.Progress
+	WorkDir  string
 }
 
 func newTestRunner(t *testing.T, opts ...runnerOption) testRunner {
@@ -47,6 +48,11 @@ func newTestRunner(t *testing.T, opts ...runnerOption) testRunner {
 
 	ctx, cancel := context.WithTimeout(context.Background(), ro.timeout)
 	t.Cleanup(cancel)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %s", err)
+	}
 
 	cln, isMoby, err := llblib.NewClient(ctx, os.Getenv("BUILDKIT_HOST"))
 	if err != nil {
@@ -69,6 +75,7 @@ func newTestRunner(t *testing.T, opts ...runnerOption) testRunner {
 		isMoby:   isMoby,
 		Solver:   llblib.NewSolver(),
 		Progress: prog,
+		WorkDir:  cwd,
 	}
 }
 


### PR DESCRIPTION
Add support for converting an llb.Def to an llb.State, this allows us to assemble a build graph from multiple opaque sources.  Adding tests around this new functionality with image config preservation and yaml marshalling.