### PR TITLE
add support and test for adhoc frontends

### DIFF
--- a/examples/custom-frontend/README.md
+++ b/examples/custom-frontend/README.md
@@ -1,0 +1,4 @@
+# custom-frontend
+
+The `custom-frontend` example is a basic buildkit frontend that takes a build option `custom:image-name` and returns the state that corresponds to that image along with the image config.
+This is used with the `TestCustomFrontend` test in the project root.

--- a/examples/custom-frontend/main.go
+++ b/examples/custom-frontend/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"braces.dev/errtrace"
+	"github.com/coryb/llblib"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/gateway/grpcclient"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/moby/buildkit/util/bklog"
+)
+
+func main() {
+	if err := grpcclient.RunFromEnvironment(
+		appcontext.Context(), build,
+	); err != nil {
+		bklog.L.Errorf("fatal error: %+v", err)
+		panic(err)
+	}
+}
+
+func build(ctx context.Context, c client.Client) (_ *client.Result, retErr error) {
+	// this custom frontend just returns a ref to the image argument, but can
+	// return any marshalled state.
+	imageName := c.BuildOpts().Opts["custom:load-image"]
+	if imageName == "" {
+		return nil, errtrace.New("custom:load-image option is required")
+	}
+
+	st := llblib.Image(imageName)
+
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, errtrace.Errorf("failed to marshal state for %s: %w", imageName, err)
+	}
+
+	res, err := c.Solve(ctx, client.SolveRequest{
+		Definition: def.ToPB(),
+	})
+	if err != nil {
+		return nil, errtrace.Errorf("failed to solve state for %s: %w", imageName, err)
+	}
+
+	if config, err := llblib.LoadImageConfig(ctx, st); err != nil {
+		return nil, errtrace.Errorf("failed to load image config for %s: %w", imageName, err)
+	} else if config != nil {
+		encodedConfig, err := json.Marshal(config)
+		if err != nil {
+			return nil, errtrace.Errorf("failed to marshal image config for %s: %w", imageName, err)
+		}
+		res.AddMeta(exptypes.ExporterImageConfigKey, encodedConfig)
+	}
+
+	return res, err
+}

--- a/frontend_test.go
+++ b/frontend_test.go
@@ -1,0 +1,58 @@
+package llblib_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/coryb/llblib"
+	"github.com/moby/buildkit/client/llb"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+var currentPlatform = ocispec.Platform{
+	OS:           "linux",
+	Architecture: runtime.GOARCH,
+}
+
+func TestCustomFrontend(t *testing.T) {
+	r := newTestRunner(t)
+
+	cachePaths := []string{
+		"/root/.cache/go-build",
+		"/go/pkg/mod",
+	}
+
+	// We are building our custom frontend from ./examples/custom-frontend,
+	// within the same solve.
+	build := llblib.Image("golang:1.22", llb.Platform(currentPlatform)).Run(
+		llb.Args([]string{"go", "build", "-C", "/src", "-o", "/out/frontend", "./examples/custom-frontend"}),
+		llb.AddMount("/out", llb.Scratch()),
+		llblib.AddCacheMounts(cachePaths, "go-cache", llb.CacheMountPrivate),
+		llb.AddMount("/src", r.Solver.Local(".", llb.IncludePatterns([]string{"**/*.go", "go.mod", "go.sum"}))),
+		llb.AddEnv("CGO_ENABLED", "0"),
+	).GetMount("/out")
+
+	// Create the frontend with our binary.
+	frontend := llb.Image("alpine", llb.Platform(currentPlatform)).File(
+		llb.Copy(build, "/", "/"),
+	).With(
+		llblib.Entrypoint("/frontend"),
+		llblib.AddLabel("moby.buildkit.frontend.caps", "moby.buildkit.frontend.inputs"),
+	)
+
+	st := llblib.Frontend(
+		"image-loader",
+		llblib.FrontendOpt("context:image-loader", "input:my-frontend"),
+		llblib.FrontendInput("my-frontend", frontend),
+		// options for our custom frontend
+		llblib.FrontendOpt("custom:load-image", alpine),
+	).With(
+		// verify that the image we get back is alpine
+		llblib.ApplyRun(llb.Args([]string{"test", "-f", "/etc/alpine-release"})),
+	)
+	req := r.Solver.Build(st)
+	resp, err := r.Run(t, req)
+	require.NoError(t, err)
+	expectConfig(t, resp.ExporterResponse[llblib.ExporterImageConfigKey])
+}

--- a/image.go
+++ b/image.go
@@ -83,9 +83,9 @@ func imageConfigToContainerConfig(img ImageConfig) ContainerConfig {
 	}
 }
 
-// imageConfig will attempt to build the image config from values stored on the
+// LoadImageConfig will attempt to build the image config from values stored on the
 // llb.State.
-func imageConfig(ctx context.Context, st llb.State) (*ImageConfig, error) {
+func LoadImageConfig(ctx context.Context, st llb.State) (*ImageConfig, error) {
 	cs, err := loadImageConfigState(ctx, st)
 	if err != nil {
 		return nil, errtrace.Wrap(err)

--- a/session.go
+++ b/session.go
@@ -162,7 +162,7 @@ func (s *session) Do(ctx context.Context, req Request) (*client.SolveResponse, e
 			}
 			return nil, errtrace.Wrap(err)
 		}
-		if spec, err := imageConfig(ctx, req.state); err != nil {
+		if spec, err := LoadImageConfig(ctx, req.state); err != nil {
 			return nil, errtrace.Wrap(err)
 		} else if spec != nil {
 			imageconfig, err = json.Marshal(spec)

--- a/state.go
+++ b/state.go
@@ -31,7 +31,7 @@ func Digest(st llb.State) (digest.Digest, error) {
 // MarshalWithImageConfig marshals the state to a definition ensuring the
 // image config state is preserved in the definition.
 func MarshalWithImageConfig(ctx context.Context, st llb.State) (*llb.Definition, error) {
-	config, err := imageConfig(ctx, st)
+	config, err := LoadImageConfig(ctx, st)
 	if err != nil {
 		return nil, err
 	}

--- a/test-data/configs/TestCustomFrontend.yaml
+++ b/test-data/configs/TestCustomFrontend.yaml
@@ -1,0 +1,25 @@
+architecture: amd64
+config:
+    Cmd:
+        - /bin/sh
+    Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+container_config:
+    Cmd:
+        - /bin/sh
+    Labels: {}
+created: "0001-01-01T00:00:00Z"
+history:
+    - created: "2024-05-22T18:18:11.872913732Z"
+      created_by: '/bin/sh -c #(nop) ADD file:e3abcdba177145039cfef1ad882f9f81a612a24c9f044b19f713b95454d2e3f6 in / '
+    - created: "2024-05-22T18:18:12.052034407Z"
+      created_by: '/bin/sh -c #(nop)  CMD ["/bin/sh"]'
+      empty_layer: true
+    - comment: llblib.v0
+      created: "0001-01-01T00:00:00Z"
+      created_by: RUN test -f /etc/alpine-release
+os: linux
+rootfs:
+    diff_ids:
+        - sha256:02f2bcb26af5ea6d185dcf509dc795746d907ae10c53918b6944ac85447a0c72
+    type: layers


### PR DESCRIPTION
also export LoadImageConfig so custom frontends can serialized any image config modifications during the solve.