### PR TITLE
add DockerTag request option

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/coryb/llblib"
+	"github.com/distribution/reference"
 	"github.com/moby/buildkit/client/llb"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
@@ -146,7 +147,9 @@ func TestDockerfileBuildContexts(t *testing.T) {
 		llblib.WithBuildContext("extra", st1),
 	)
 
-	req := r.Solver.Build(st)
+	ref, err := reference.Parse("llblib-test/dockerfile-build-contexts")
+	require.NoError(t, err)
+	req := r.Solver.Build(st, llblib.DockerTag(ref))
 	_, err = r.Run(t, req)
 	require.NoError(t, err)
 }

--- a/dockerload.go
+++ b/dockerload.go
@@ -27,3 +27,15 @@ func DockerSave(ref reference.Reference, output io.WriteCloser) RequestOption {
 		)
 	})
 }
+
+// DockerTag will tag the build state as a docker image with the given reference.
+func DockerTag(ref reference.Reference) RequestOption {
+	return requestOptionFunc(func(r *Request) {
+		r.exports = append(r.exports, client.ExportEntry{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": ref.String(),
+			},
+		})
+	})
+}


### PR DESCRIPTION
When used with `BUILDKIT_HOST=docker://` you can use DockerTag to simulate `docker build --tag <name>`